### PR TITLE
[DOC] Refactor metrics plugin spi class

### DIFF
--- a/docs/design/spi-design.md
+++ b/docs/design/spi-design.md
@@ -17,7 +17,7 @@ SPI, called Service Provider Interface, is a built-in JDK Service that provides 
 
 ### Metrics Center
 
-Responsible for service monitoring, loading concrete implementation through `SPI`, currently support `Prometheus`, service interface is `MetricsBootService`.
+Responsible for service monitoring, loading concrete implementation through `SPI`, currently support `Prometheus`, service interface is `MetricsService`.
 
 
 

--- a/docs/developer/spi/custom-metrics-monitor.md
+++ b/docs/developer/spi/custom-metrics-monitor.md
@@ -9,7 +9,7 @@ description: custom Metrics Monitor
 
 * Before custom development, please customize and build the gateway environment first, please refer to: [custom deployment](../deployment-custom)
 
-* This article describes how to customize the extension of  `org.apache.shenyu.metrics.spi.MetricsBootService`.
+* This article describes how to customize the extension of  `org.apache.shenyu.plugin.metrics.spi.MetricsService`.
 
 ## Extension
 
@@ -25,10 +25,10 @@ description: custom Metrics Monitor
 </dependencies>
 ```
 
-* Create a new class `${you class}`，implements `org.apache.shenyu.metrics.spi.MetricsBootService`
+* Create a new class `${you class}`，implements `org.apache.shenyu.plugin.metrics.spi.MetricsService`
 
 ```
-public class ${you class} implements MetricsBootService {
+public class ${you class} implements MetricsService {
    
    	/**
      * Start metrics tracker.
@@ -49,7 +49,7 @@ public class ${you class} implements MetricsBootService {
 }
 ```
 
-* In the project  `resources` directory，Create a new `META-INF/shenyu` directory， and the new file name is : `org.apache.shenyu.metrics.spi.MetricsBootService`.
+* In the project  `resources` directory，Create a new `META-INF/shenyu` directory， and the new file name is : `org.apache.shenyu.plugin.metrics.spi.MetricsService`.
 add `${you spi name}` = `${you class path}`:
 
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/design/spi-design.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/design/spi-design.md
@@ -15,7 +15,7 @@ description:  对ShenYu网关中SPI的使用进行介绍
 
 ### 监控中心扩展
 
-负责服务的监控，通过`SPI`加载具体实现，当前支持`Prometheus` ，服务接口是 `MetricsBootService` 。
+负责服务的监控，通过`SPI`加载具体实现，当前支持`Prometheus` ，服务接口是 `MetricsService` 。
 
 ### 负载均衡扩展
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/developer/spi/custom-metrics-monitor.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/developer/spi/custom-metrics-monitor.md
@@ -7,7 +7,7 @@ description: 自定义指标监控
 
 * 在自定义开发前，请先自定义搭建好网关环境，请参考: [自定义部署](../../deployment/deployment-custom)
 
-* 本文介绍如何对 `org.apache.shenyu.metrics.spi.MetricsBootService` 进行自定义扩展。
+* 本文介绍如何对 `org.apache.shenyu.plugin.metrics.spi.MetricsService` 进行自定义扩展。
 
 ## 扩展实现
 
@@ -23,10 +23,10 @@ description: 自定义指标监控
 </dependencies>
 ```
 
-* 新增一个类 `${you class}`，实现 `org.apache.shenyu.metrics.spi.MetricsBootService`
+* 新增一个类 `${you class}`，实现 `org.apache.shenyu.plugin.metrics.spi.MetricsService`
 
 ```java
-public class ${you class} implements MetricsBootService {
+public class ${you class} implements MetricsService {
    
    	/**
      * Start metrics tracker.
@@ -47,7 +47,7 @@ public class ${you class} implements MetricsBootService {
 }
 ```
 
-* 在项目 `resources` 目录下，新建 `META-INF/shenyu` 目录， 并且新增文件名为 : `org.apache.shenyu.metrics.spi.MetricsBootService`.
+* 在项目 `resources` 目录下，新建 `META-INF/shenyu` 目录， 并且新增文件名为 : `org.apache.shenyu.plugin.metrics.spi.MetricsService`.
 内容新增 `${you spi name}` = `${you class path}`:
 
 ```


### PR DESCRIPTION
hi, community.

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/63457588/186912316-246f6966-12e8-47e9-a202-0adc67c1ff3f.png">


I found that the SPI class of metrics seems to haven't been updated after refactoring.  I have updated the current version document.  