### PR TITLE
[DOC] update helm deployment doc for prerequisites and version

### DIFF
--- a/helm/index.md
+++ b/helm/index.md
@@ -5,6 +5,15 @@ description: Helm Deployment
 
 This article introduces the use of `helm` to deploy the `Apache ShenYu` gateway.
 
+## Prerequisites
+
+### Tools
+
+* [Kubernetes &＆ Kubectl](https://kubernetes.io/docs/setup/)
+* [Helm](https://helm.sh/docs/intro/install/)
+
+### Database
+
 > Before you read this document, you need to complete some preparations before deploying Shenyu according to the [Deployment Prerequisites document](https://shenyu.apache.org/docs/deployment/deployment-before/).
 
 ## Add Helm repository
@@ -139,24 +148,29 @@ helm install shenyu shenyu/shenyu -n=shenyu --create-namespace \
 
 | configuration item | type   | default   | description                                                                                        |
 |--------------------|--------|-----------|----------------------------------------------------------------------------------------------------|
-| replicas           | int    | `1`       | Number of replicas                                                                                 |
 | version            | string | `"2.5.0"` | shenyu version, it is not recommended to modify, please install the corresponding version directly |
 
 ### shenyu-admin configuration
 
-| configuration item | type   | default                                                                                                     | description        |
-|--------------------|--------|-------------------------------------------------------------------------------------------------------------|--------------------|
-| admin.nodePort     | int    | `31095`                                                                                                     | NodePort port      |
-| admin.javaOpts     | string | [see here](https://github.com/apache/shenyu/blob/master/shenyu-dist/shenyu-admin-dist/docker/entrypoint.sh) | JVM parameters     |
-| admin.resources    | dict   | omit                                                                                                        | K8s resource quota |
+| configuration item | type   | default                                                                                                     | description                                                     |
+|--------------------|--------|-------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| admin.enabled      | bool   | `true`                                                                                                      | whether to install admin                                        |
+| admin.replicas     | int    | `1`                                                                                                         | number of replicas                                              |
+| admin.image        | string | `"apache/shenyu-admin"`                                                                                     | image name (you can modify this field to support custom images) |
+| admin.nodePort     | int    | `31095`                                                                                                     | NodePort port                                                   |
+| admin.javaOpts     | string | [see here](https://github.com/apache/shenyu/blob/master/shenyu-dist/shenyu-admin-dist/docker/entrypoint.sh) | JVM parameters                                                  |
+| admin.resources    | dict   | omit                                                                                                        | K8s resource quota                                              |
 
 ### shenyu-bootstrap configuration
 
-| configuration item  | type   | default                                                                                                         | description        |
-|---------------------|--------|-----------------------------------------------------------------------------------------------------------------|--------------------|
-| bootstrap.nodePort  | int    | `31195`                                                                                                         | NodePort Port      |
-| bootstrap.javaOpts  | string | [see here](https://github.com/apache/shenyu/blob/master/shenyu-dist/shenyu-bootstrap-dist/docker/entrypoint.sh) | JVM parameters     |
-| bootstrap.resources | dict   | `{}`                                                                                                            | K8s resource quota |
+| configuration item  | type   | default                                                                                                         | description                                                     |
+|---------------------|--------|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| bootstrap.enabled   | bool   | `true`                                                                                                          | whether to install bootstrap                                    |
+| bootstrap.replicas  | int    | `2`                                                                                                             | number of replicas                                              |
+| bootstrap.image     | string | `"apache/shenyu-bootstrap"`                                                                                     | image name (you can modify this field to support custom images) |
+| bootstrap.nodePort  | int    | `31195`                                                                                                         | NodePort Port                                                   |
+| bootstrap.javaOpts  | string | [see here](https://github.com/apache/shenyu/blob/master/shenyu-dist/shenyu-bootstrap-dist/docker/entrypoint.sh) | JVM parameters                                                  |
+| bootstrap.resources | dict   | `{}`                                                                                                            | K8s resource quota                                              |
 
 ### Database configuration
 

--- a/i18n/zh/docusaurus-plugin-content-docs-helm/current/index.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-helm/current/index.md
@@ -6,6 +6,15 @@ description: Helm部署
 
 本文介绍使用 `helm` 来部署 `Apache ShenYu` 网关。
 
+## 先决条件
+
+### 工具
+
+* [Kubernetes &＆ Kubectl](https://kubernetes.io/zh-cn/docs/setup/)
+* [Helm](https://helm.sh/zh/docs/intro/install/)
+
+### 数据库
+
 > 在阅读本文档前，你需要先阅读[部署先决条件](https://shenyu.apache.org/zh/docs/deployment/deployment-before)文档来完成部署 `shenyu` 前的环境准备工作。
 
 ## 添加 Helm 仓库
@@ -134,26 +143,31 @@ helm install shenyu shenyu/shenyu -n=shenyu --create-namespace \
 
 ### 全局配置
 
-| 配置项    | 类型    | 默认值     | 描述                                   |
-|----------|--------|-----------|---------------------------------------|
-| replicas | int    | `1`       | 副本数量                               |
-| version  | string | `"2.5.0"` | shenyu 版本，不建议修改，请直接安装对应版本 |
+| 配置项   | 类型    | 默认值     | 描述                                   |
+|---------|--------|-----------|---------------------------------------|
+| version | string | `"2.5.0"` | shenyu 版本，不建议修改，请直接安装对应版本 |
 
 ### shenyu-admin 配置
 
-| 配置项           | 类型    | 默认值                                                                                                      | 描述          |
-|-----------------|--------|------------------------------------------------------------------------------------------------------------|--------------|
-| admin.nodePort  | int    | `31095`                                                                                                    | NodePort 端口 |
-| admin.javaOpts  | string | [详见这里](https://github.com/apache/shenyu/blob/master/shenyu-dist/shenyu-admin-dist/docker/entrypoint.sh) | JVM 参数      |
-| admin.resources | dict   | `{}`                                                                                                       | K8s 资源配额  |
+| 配置项           | 类型    | 默认值                                                                                                      | 描述                                 |
+|-----------------|--------|------------------------------------------------------------------------------------------------------------|-------------------------------------|
+| admin.enabled   | bool   | `true`                                                                                                     | 是否安装 admin                       |
+| admin.replicas  | int    | `1`                                                                                                        | 副本数量                             |
+| admin.image     | string | `"apache/shenyu-admin"`                                                                                    | 镜像名称（可以修改此字段以支持定制化镜像） |
+| admin.nodePort  | int    | `31095`                                                                                                    | NodePort 端口                        |
+| admin.javaOpts  | string | [详见这里](https://github.com/apache/shenyu/blob/master/shenyu-dist/shenyu-admin-dist/docker/entrypoint.sh) | JVM 参数                             |
+| admin.resources | dict   | `{}`                                                                                                       | K8s 资源配额                         |
 
 ### shenyu-bootstrap 配置
 
-| 配置项               | 类型    | 默认值                                                                                                          | 描述          |
-|---------------------|--------|----------------------------------------------------------------------------------------------------------------|--------------|
-| bootstrap.nodePort  | int    | `31195`                                                                                                        | NodePort 端口 |
-| bootstrap.javaOpts  | string | [详见这里](https://github.com/apache/shenyu/blob/master/shenyu-dist/shenyu-bootstrap-dist/docker/entrypoint.sh) | JVM 参数      |
-| bootstrap.resources | dict   | `{}`                                                                                                           | K8s 资源配额  |
+| 配置项               | 类型    | 默认值                                                                                                          | 描述                                 |
+|---------------------|--------|----------------------------------------------------------------------------------------------------------------|-------------------------------------|
+| bootstrap.enabled   | bool   | `true`                                                                                                         | 是否安装 bootstrap                   |
+| bootstrap.replicas  | int    | `2`                                                                                                            | 副本数量                             |
+| bootstrap.image     | string | `"apache/shenyu-bootstrap"`                                                                                    | 镜像名称（可以修改此字段以支持定制化镜像） |
+| bootstrap.nodePort  | int    | `31195`                                                                                                        | NodePort 端口                        |
+| bootstrap.javaOpts  | string | [详见这里](https://github.com/apache/shenyu/blob/master/shenyu-dist/shenyu-bootstrap-dist/docker/entrypoint.sh) | JVM 参数                             |
+| bootstrap.resources | dict   | `{}`                                                                                                           | K8s 资源配额                         |
 
 ### 数据库配置
 

--- a/src/data/docsInfo.js
+++ b/src/data/docsInfo.js
@@ -68,5 +68,8 @@ export default [
       <Translate>Helm deployment documentation written for ShenYu</Translate>
     ),
     latestVersion: "/helm/index",
+    versionsList: [
+      {"for ShenYu 2.5.0": "/helm/index"},
+    ]
   },
 ];


### PR DESCRIPTION
Signed-off-by: Bird <aflybird0@gmail.com>

1. 更新安装工具链接
2. 填补之前漏掉的几个配置说明
3. 文档增加版本。不同于其他项目，Helm的文档版本做了些改动：
  * 没有 "next" 版本，目前每改一次就发一次版，所以都是先release再改文档。或许以后可以把改动和发版分开。目前apisix是在积攒了一定的改动后，手动改一下chart.yaml的版本号然后发版，jenkinsci是每次改动都发版。prometheus也是只要对chart做了改动就发版
  * 不是一个 "chart版本" 一个文档，chart发版肯定远快于 shenyu 本身，所以一个 shenyu 版本对应 n 个 chart 版本，所以一个chart文档目前设计的对应1一个shenyu版本，并且只维护最新版的chart的文档。（其他的通过兼容性保证）

下面是prometheus的关于chart版本的要求：

![image](https://user-images.githubusercontent.com/36830265/203058976-7e5ee3d7-93cc-4e69-a2ea-b703b65801b6.png)


https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements