### PR TITLE
update package download link which shenyu current version is v2.5.1

### DIFF
--- a/docs/deployment/deployment-cluster.md
+++ b/docs/deployment/deployment-cluster.md
@@ -1,17 +1,17 @@
 ---
 sidebar_position: 7
 title: Cluster Deployment
-keywords: ["Gateway Cluster Enviroment", "Cluster Enviroment"]
-description: Cluster Delopyment
+keywords: ["Gateway Cluster Environment", "Cluster Environment"]
+description: Cluster Deployment
 ---
 
 > Before you read this document, you need to complete some preparations before deploying Shenyu according to the [Deployment Prerequisites document](./deployment-before.md).
 
-This aritcle introduces how to delopy the `Shenyu` gateway in cluster enviroment.
+This article introduces how to deploy the `Shenyu` gateway in cluster environment.
 
 > In this part, you can see  [ShenYu Binary Packages Deployment](./deployment-package.md) before deploying.
 
-### Enviromental Preparation
+### Environmental Preparation
 
 * Two or more Gateway Boostrap servers, these servers must install JDK1.8+.
 * A server for Gateway Admin, this server must install mysql/pgsql/h2 and JDK1.8+.
@@ -19,7 +19,7 @@ This aritcle introduces how to delopy the `Shenyu` gateway in cluster enviroment
 
 ### Start Apache ShenYu Admin
 
-* download and unzip [apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/incubator/shenyu/2.5.0/apache-shenyu-2.5.0-admin-bin.tar.gz) in your Gateway Admin server.
+* download and unzip [apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/incubator/shenyu/2.5.1/apache-shenyu-2.5.1-admin-bin.tar.gz) in your Gateway Admin server.
 
 * config your database, go to the `/conf` directory, and  modify `spring.profiles.active` of the configuration in `application.yaml` to `mysql`, `pg` or `h2`.
 
@@ -35,7 +35,7 @@ This aritcle introduces how to delopy the `Shenyu` gateway in cluster enviroment
 
 ### Start Apache ShenYu Boostrap
 
-* download and unzip [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/incubator/shenyu/2.5.0/apache-shenyu-2.5.0-bootstrap-bin.tar.gz) in your Gateway Boostrap server.
+* download and unzip [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/incubator/shenyu/2.5.1/apache-shenyu-2.5.1-bootstrap-bin.tar.gz) in your Gateway Boostrap server.
 
 * config your synchronization, go to the `/conf` directory, and modify `shenyu.sync` of configuration in `application.yaml` to `websocket`, `http`, `zookeeper`, `etcd`, `consul` or `nacos`, this configuaration must remain the same of `ShenyYu Admin`.
 

--- a/docs/deployment/deployment-package.md
+++ b/docs/deployment/deployment-package.md
@@ -11,7 +11,7 @@ This article introduces the deployment of the `Apache ShenYu` gateway using the 
 
 ### Start Apache ShenYu Admin
 
-* download [apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-2.5.0-admin-bin.tar.gz)
+* download [apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-2.5.1-admin-bin.tar.gz)
 
 * unzip `apache-shenyu-${current.version}-admin-bin.tar.gz`。 go to the `bin` directory.
 
@@ -57,7 +57,7 @@ This article introduces the deployment of the `Apache ShenYu` gateway using the 
 
 ### Start Apache ShenYu Bootstrap
 
-* download [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-2.5.0-bootstrap-bin.tar.gz)
+* download [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-2.5.1-bootstrap-bin.tar.gz)
 
 * unzip `apache-shenyu-${current.version}-bootstrap-bin.tar.gz`。 go to the `bin` directory.
 

--- a/docs/deployment/deployment-quick.md
+++ b/docs/deployment/deployment-quick.md
@@ -5,7 +5,7 @@ keywords: ["Deployment"]
 description: Local Quick Deployment
 ---
 
-This article introduces how to quick start the `Apache ShenYu` gateway in the standalone environment.
+This article introduces how to quickly start the `Apache ShenYu` gateway in the standalone environment.
 
 > Before you read this document, you need to complete some preparations before deploying Shenyu according to the [Deployment Prerequisites document](./deployment-before.md).
 
@@ -15,7 +15,7 @@ This article introduces how to quick start the `Apache ShenYu` gateway in the st
 
 ### Start Apache ShenYu Bootstrap
 
-* download [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-2.5.0-bootstrap-bin.tar.gz)
+* download [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-2.5.1-bootstrap-bin.tar.gz)
 
 * unzip `apache-shenyu-${current.version}-bootstrap-bin.tar.gz`。 go to the `bin` directory.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/deployment/deployment-cluster.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/deployment/deployment-cluster.md
@@ -19,7 +19,7 @@ description: 集群部署
 
 ### 启动 Apache ShenYu Admin
 
-* 在你的网关管理端服务器下载并解压[apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-incubating-2.5.0-admin-bin.tar.gz) 。
+* 在你的网关管理端服务器下载并解压[apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-incubating-2.5.1-admin-bin.tar.gz) 。
 
 * 配置你的数据库，进入`/conf`目录，在`application.yaml`文件中修改`spring.profiles.active`节点为`mysql`, `pg` or `h2`。
 
@@ -35,7 +35,7 @@ description: 集群部署
 
 ### 启动 Apache ShenYu Boostrap
 
-* 在你的网关启动器服务器下载并解压[apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-incubating-2.5.0-bootstrap-bin.tar.gz) 。
+* 在你的网关启动器服务器下载并解压[apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-incubating-2.5.1-bootstrap-bin.tar.gz) 。
 
 * 配置你的数据同步方式，进入`/conf`目录，在`application.yaml`文件中修改`shenyu.sync`节点为`websocket`, `http`, `zookeeper`, `etcd`, `consul` 或者 `nacos`，这个配置必须与`ShenyYu Admin`的配置保持相同。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/deployment/deployment-package.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/deployment/deployment-package.md
@@ -12,7 +12,7 @@ description: 二进制包部署
 
 ### 启动 Apache ShenYu Admin
 
-* 下载 [apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-2.5.0-admin-bin.tar.gz)
+* 下载 [apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-2.5.1-admin-bin.tar.gz)
 
 * 解压缩 `apache-shenyu-${current.version}-admin-bin.tar.gz`。 进入 `bin` 目录。
 
@@ -58,7 +58,7 @@ description: 二进制包部署
 
 ### 启动 Apache ShenYu Bootstrap
 
-* 下载 [`apache-shenyu-${current.version}-bootstrap-bin.tar.gz`](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-2.5.0-bootstrap-bin.tar.gz)
+* 下载 [`apache-shenyu-${current.version}-bootstrap-bin.tar.gz`](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-2.5.1-bootstrap-bin.tar.gz)
 
 * 解压缩 `apache-shenyu-${current.version}-bootstrap-bin.tar.gz`。 进入 bin 目录。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/deployment/deployment-quick.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/deployment/deployment-quick.md
@@ -15,7 +15,7 @@ description: 单机快速部署
 
 ### 启动 Apache ShenYu Bootstrap
 
-* 下载 [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-2.5.0-bootstrap-bin.tar.gz)
+* 下载 [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-2.5.1-bootstrap-bin.tar.gz)
 
 * 解压缩 `apache-shenyu-${current.version}-bootstrap-bin.tar.gz`。 进入 bin 目录。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.5.1/deployment/deployment-cluster.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.5.1/deployment/deployment-cluster.md
@@ -19,7 +19,7 @@ description: 集群部署
 
 ### 启动 Apache ShenYu Admin
 
-* 在你的网关管理端服务器下载并解压[apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-incubating-2.5.0-admin-bin.tar.gz) 。
+* 在你的网关管理端服务器下载并解压[apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-incubating-2.5.1-admin-bin.tar.gz) 。
 
 * 配置你的数据库，进入`/conf`目录，在`application.yaml`文件中修改`spring.profiles.active`节点为`mysql`, `pg` or `h2`。
 
@@ -35,7 +35,7 @@ description: 集群部署
 
 ### 启动 Apache ShenYu Boostrap
 
-* 在你的网关启动器服务器下载并解压[apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-incubating-2.5.0-bootstrap-bin.tar.gz) 。
+* 在你的网关启动器服务器下载并解压[apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-incubating-2.5.1-bootstrap-bin.tar.gz) 。
 
 * 配置你的数据同步方式，进入`/conf`目录，在`application.yaml`文件中修改`shenyu.sync`节点为`websocket`, `http`, `zookeeper`, `etcd`, `consul` 或者 `nacos`，这个配置必须与`ShenyYu Admin`的配置保持相同。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.5.1/deployment/deployment-package.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.5.1/deployment/deployment-package.md
@@ -12,7 +12,7 @@ description: 二进制包部署
 
 ### 启动 Apache ShenYu Admin
 
-* 下载 [apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-2.5.0-admin-bin.tar.gz)
+* 下载 [apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-2.5.1-admin-bin.tar.gz)
 
 * 解压缩 `apache-shenyu-${current.version}-admin-bin.tar.gz`。 进入 `bin` 目录。
 
@@ -58,7 +58,7 @@ description: 二进制包部署
 
 ### 启动 Apache ShenYu Bootstrap
 
-* 下载 [`apache-shenyu-${current.version}-bootstrap-bin.tar.gz`](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-2.5.0-bootstrap-bin.tar.gz)
+* 下载 [`apache-shenyu-${current.version}-bootstrap-bin.tar.gz`](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-2.5.1-bootstrap-bin.tar.gz)
 
 * 解压缩 `apache-shenyu-${current.version}-bootstrap-bin.tar.gz`。 进入 bin 目录。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.5.1/deployment/deployment-quick.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.5.1/deployment/deployment-quick.md
@@ -15,7 +15,7 @@ description: 单机快速部署
 
 ### 启动 Apache ShenYu Bootstrap
 
-* 下载 [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-2.5.0-bootstrap-bin.tar.gz)
+* 下载 [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-2.5.1-bootstrap-bin.tar.gz)
 
 * 解压缩 `apache-shenyu-${current.version}-bootstrap-bin.tar.gz`。 进入 bin 目录。
 

--- a/versioned_docs/version-2.5.1/deployment/deployment-cluster.md
+++ b/versioned_docs/version-2.5.1/deployment/deployment-cluster.md
@@ -1,17 +1,17 @@
 ---
 sidebar_position: 7
 title: Cluster Deployment
-keywords: ["Gateway Cluster Enviroment", "Cluster Enviroment"]
-description: Cluster Delopyment
+keywords: ["Gateway Cluster Environment", "Cluster Environment"]
+description: Cluster Deployment
 ---
 
 > Before you read this document, you need to complete some preparations before deploying Shenyu according to the [Deployment Prerequisites document](./deployment-before.md).
 
-This aritcle introduces how to delopy the `Shenyu` gateway in cluster enviroment.
+This article introduces how to deploy the `Shenyu` gateway in cluster environment.
 
 > In this part, you can see  [ShenYu Binary Packages Deployment](./deployment-package.md) before deploying.
 
-### Enviromental Preparation
+### Environmental Preparation
 
 * Two or more Gateway Boostrap servers, these servers must install JDK1.8+.
 * A server for Gateway Admin, this server must install mysql/pgsql/h2 and JDK1.8+.
@@ -19,7 +19,7 @@ This aritcle introduces how to delopy the `Shenyu` gateway in cluster enviroment
 
 ### Start Apache ShenYu Admin
 
-* download and unzip [apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/incubator/shenyu/2.5.0/apache-shenyu-2.5.0-admin-bin.tar.gz) in your Gateway Admin server.
+* download and unzip [apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/incubator/shenyu/2.5.1/apache-shenyu-2.5.1-admin-bin.tar.gz) in your Gateway Admin server.
 
 * config your database, go to the `/conf` directory, and  modify `spring.profiles.active` of the configuration in `application.yaml` to `mysql`, `pg` or `h2`.
 
@@ -35,7 +35,7 @@ This aritcle introduces how to delopy the `Shenyu` gateway in cluster enviroment
 
 ### Start Apache ShenYu Boostrap
 
-* download and unzip [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/incubator/shenyu/2.5.0/apache-shenyu-2.5.0-bootstrap-bin.tar.gz) in your Gateway Boostrap server.
+* download and unzip [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/incubator/shenyu/2.5.1/apache-shenyu-2.5.1-bootstrap-bin.tar.gz) in your Gateway Boostrap server.
 
 * config your synchronization, go to the `/conf` directory, and modify `shenyu.sync` of configuration in `application.yaml` to `websocket`, `http`, `zookeeper`, `etcd`, `consul` or `nacos`, this configuaration must remain the same of `ShenyYu Admin`.
 

--- a/versioned_docs/version-2.5.1/deployment/deployment-package.md
+++ b/versioned_docs/version-2.5.1/deployment/deployment-package.md
@@ -11,7 +11,7 @@ This article introduces the deployment of the `Apache ShenYu` gateway using the 
 
 ### Start Apache ShenYu Admin
 
-* download [apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-2.5.0-admin-bin.tar.gz)
+* download [apache-shenyu-${current.version}-admin-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-2.5.1-admin-bin.tar.gz)
 
 * unzip `apache-shenyu-${current.version}-admin-bin.tar.gz`。 go to the `bin` directory.
 
@@ -57,7 +57,7 @@ This article introduces the deployment of the `Apache ShenYu` gateway using the 
 
 ### Start Apache ShenYu Bootstrap
 
-* download [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-2.5.0-bootstrap-bin.tar.gz)
+* download [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-2.5.1-bootstrap-bin.tar.gz)
 
 * unzip `apache-shenyu-${current.version}-bootstrap-bin.tar.gz`。 go to the `bin` directory.
 

--- a/versioned_docs/version-2.5.1/deployment/deployment-quick.md
+++ b/versioned_docs/version-2.5.1/deployment/deployment-quick.md
@@ -5,7 +5,7 @@ keywords: ["Deployment"]
 description: Local Quick Deployment
 ---
 
-This article introduces how to quick start the `Apache ShenYu` gateway in the standalone environment.
+This article introduces how to quickly start the `Apache ShenYu` gateway in the standalone environment.
 
 > Before you read this document, you need to complete some preparations before deploying Shenyu according to the [Deployment Prerequisites document](./deployment-before.md).
 
@@ -15,7 +15,7 @@ This article introduces how to quick start the `Apache ShenYu` gateway in the st
 
 ### Start Apache ShenYu Bootstrap
 
-* download [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.0/apache-shenyu-2.5.0-bootstrap-bin.tar.gz)
+* download [apache-shenyu-${current.version}-bootstrap-bin.tar.gz](https://archive.apache.org/dist/shenyu/2.5.1/apache-shenyu-2.5.1-bootstrap-bin.tar.gz)
 
 * unzip `apache-shenyu-${current.version}-bootstrap-bin.tar.gz`。 go to the `bin` directory.
 


### PR DESCRIPTION
- update shenyu package download link `2.5.0` to `2.5.1` due current version is 2.5.1
- fix some wrong word