### PR TITLE
[Improve] fix "Quick start with Spring Cloud" link 404 for Spring Cloud Proxy page

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6.1/user-guide/proxy/spring-cloud-proxy.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6.1/user-guide/proxy/spring-cloud-proxy.md
@@ -6,7 +6,7 @@ description: SpringCloud接入ShenYu网关
 
 此篇文章是介绍 `springCloud` 服务接入到 `Apache ShenYu` 网关，`Apache ShenYu` 网关使用 `springCloud` 插件来接入`Spring Cloud`服务。
 
-接入前，请正确启动 `shenyu-admin`，并开启`springCloud`插件，在网关端和`springCloud`服务端引入相关依赖。可以参考前面的 [Spring Cloud快速开始](../quick-start/quick-start-springcloud)。
+接入前，请正确启动 `shenyu-admin`，并开启`springCloud`插件，在网关端和`springCloud`服务端引入相关依赖。可以参考前面的 [Spring Cloud快速开始](../../quick-start/quick-start-springcloud)。
 
 应用客户端接入的相关配置请参考：[客户端接入配置](../property-config/register-center-access.md)。
 

--- a/versioned_docs/version-2.6.1/user-guide/proxy/spring-cloud-proxy.md
+++ b/versioned_docs/version-2.6.1/user-guide/proxy/spring-cloud-proxy.md
@@ -6,7 +6,7 @@ description: springCloud with shenyu gateway
 
 This document is intended to help the `Spring Cloud` service access the `Apache ShenYu` gateway. The `Apache ShenYu` gateway uses the `springCloud` plugin to handle `Spring Cloud` service.
 
-Before the connection, start `shenyu-admin` correctly, start `springCloud` plugin, and add related dependencies on the gateway and `springCloud` application client. Refer to the previous [Quick start with Spring Cloud](../quick-start/quick-start-springcloud) .
+Before the connection, start `shenyu-admin` correctly, start `springCloud` plugin, and add related dependencies on the gateway and `springCloud` application client. Refer to the previous [Quick start with Spring Cloud](../../quick-start/quick-start-springcloud) .
 
 For details about client access configuration, see [Application Client Access Config](../property-config/register-center-access.md) .
 


### PR DESCRIPTION
fix link 404

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/ce8ae756-255e-4890-9629-75d4dd13c9de">
