### PR TITLE
docs: update JDK requirement from 1.8 to 17+

### DIFF
--- a/docs/deployment/deployment-cluster.md
+++ b/docs/deployment/deployment-cluster.md
@@ -13,8 +13,8 @@ This article introduces how to deploy the `Shenyu` gateway in cluster environmen
 
 ### Environmental Preparation
 
-* Two or more Gateway Boostrap servers, these servers must install JDK1.8+.
-* A server for Gateway Admin, this server must install mysql/pgsql/h2 and JDK1.8+.
+* Two or more Gateway Boostrap servers, these servers must install JDK17+.
+* A server for Gateway Admin, this server must install mysql/pgsql/h2 and JDK17+.
 * A server for nginx.
 
 ### Start Apache ShenYu Admin

--- a/docs/deployment/deployment-quick.md
+++ b/docs/deployment/deployment-quick.md
@@ -11,7 +11,7 @@ This article introduces how to quickly start the `Apache ShenYu` gateway in the 
 
 ### Environmental preparation
 
-* Install JDK1.8+ locally
+* Install JDK17+ locally
 
 ### Start Apache ShenYu Bootstrap
 


### PR DESCRIPTION
## Summary

Update the JDK requirement in deployment documentation to reflect the actual minimum version required by the codebase.

## Changes

- `docs/deployment/deployment-quick.md`: Update JDK requirement from 1.8+ to 17+
- `docs/deployment/deployment-cluster.md`: Update JDK requirement from 1.8+ to 17+

## Motivation

The project `pom.xml` specifies `java.version=17` and the README documents JDK 17+ as the minimum requirement. The deployment docs still referenced JDK 1.8+, which is incorrect and could mislead users.