### PR TITLE
[ISSUE #6396] Document Admin network isolation requirements.

### DIFF
--- a/docs/deployment/deployment-before.md
+++ b/docs/deployment/deployment-before.md
@@ -54,3 +54,11 @@ In [the openGuass initialization scripts directory](https://github.com/apache/sh
 
   * maven repository: https://mvnrepository.com/artifact/org.opengauss/opengauss-jdbc/5.0.0-og
   * homepage:  https://gitee.com/opengauss/openGauss-connector-jdbc
+
+## Deployment Security Checklist
+
+Before deploying Apache ShenYu in production, verify the following Admin-plane network controls:
+
+- [ ] Restrict the ShenYu Admin listening port to trusted internal networks and authorized operators or Gateway nodes by using firewall rules, security groups, Kubernetes `NetworkPolicy`, or equivalent controls.
+- [ ] Do not expose the Admin `/websocket` endpoint to public or otherwise untrusted networks. The endpoint is unauthenticated by design because it is used for data synchronization between ShenYu Admin and Gateway nodes, so it must be protected by network-level access controls.
+- [ ] Expose the Gateway data plane separately, and do not publish the Admin plane through a public load balancer or Ingress.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/deployment/deployment-before.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/deployment/deployment-before.md
@@ -54,3 +54,11 @@ description: 部署先决条件
 
   * maven repository: https://mvnrepository.com/artifact/org.opengauss/opengauss-jdbc/5.0.0-og
   * homepage:  https://gitee.com/opengauss/openGauss-connector-jdbc
+
+## 部署安全检查清单
+
+在生产环境部署 Apache ShenYu 前，请确认管理平面已采取以下网络安全措施：
+
+- [ ] 通过防火墙规则、安全组、Kubernetes `NetworkPolicy` 或同等措施，将 ShenYu Admin 监听端口限制在可信内部网络，并仅允许授权运维人员或 Gateway 节点访问。
+- [ ] 不要将 Admin 的 `/websocket` 端点暴露到公网或其他不可信网络。该端点用于 ShenYu Admin 与 Gateway 节点之间的数据同步，因此按设计不进行身份认证，必须依靠网络层访问控制进行保护。
+- [ ] 将 Gateway 数据平面与 Admin 管理平面分开暴露，不要通过公网负载均衡器或 Ingress 发布 Admin 管理平面。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.3/deployment/deployment-before.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.3/deployment/deployment-before.md
@@ -54,3 +54,11 @@ description: 部署先决条件
 
   * maven repository: https://mvnrepository.com/artifact/org.opengauss/opengauss-jdbc/5.0.0-og
   * homepage:  https://gitee.com/opengauss/openGauss-connector-jdbc
+
+## 部署安全检查清单
+
+在生产环境部署 Apache ShenYu 前，请确认管理平面已采取以下网络安全措施：
+
+- [ ] 通过防火墙规则、安全组、Kubernetes `NetworkPolicy` 或同等措施，将 ShenYu Admin 监听端口限制在可信内部网络，并仅允许授权运维人员或 Gateway 节点访问。
+- [ ] 不要将 Admin 的 `/websocket` 端点暴露到公网或其他不可信网络。该端点用于 ShenYu Admin 与 Gateway 节点之间的数据同步，因此按设计不进行身份认证，必须依靠网络层访问控制进行保护。
+- [ ] 将 Gateway 数据平面与 Admin 管理平面分开暴露，不要通过公网负载均衡器或 Ingress 发布 Admin 管理平面。

--- a/versioned_docs/version-2.7.0.3/deployment/deployment-before.md
+++ b/versioned_docs/version-2.7.0.3/deployment/deployment-before.md
@@ -54,3 +54,11 @@ In [the openGuass initialization scripts directory](https://github.com/apache/sh
 
   * maven repository: https://mvnrepository.com/artifact/org.opengauss/opengauss-jdbc/5.0.0-og
   * homepage:  https://gitee.com/opengauss/openGauss-connector-jdbc
+
+## Deployment Security Checklist
+
+Before deploying Apache ShenYu in production, verify the following Admin-plane network controls:
+
+- [ ] Restrict the ShenYu Admin listening port to trusted internal networks and authorized operators or Gateway nodes by using firewall rules, security groups, Kubernetes `NetworkPolicy`, or equivalent controls.
+- [ ] Do not expose the Admin `/websocket` endpoint to public or otherwise untrusted networks. The endpoint is unauthenticated by design because it is used for data synchronization between ShenYu Admin and Gateway nodes, so it must be protected by network-level access controls.
+- [ ] Expose the Gateway data plane separately, and do not publish the Admin plane through a public load balancer or Ingress.


### PR DESCRIPTION
## What this PR does

Adds an Admin-plane deployment security checklist to the current and 2.7.0.3 English and Chinese documentation.

The checklist explains that:

- the ShenYu Admin listening port must be restricted to trusted networks;
- `/websocket` is unauthenticated by design for Admin-to-Gateway data synchronization and requires network-level protection;
- the Gateway data plane and Admin management plane should be exposed separately.

## Verification

- Ran `markdownlint-cli@0.25.0` against all four changed documentation files.

Related to apache/shenyu#6396.