### PR TITLE
fix: correct Helm deployment links from /helm/index/ to /helm/

### DIFF
--- a/docs/deployment/deployment-helm.md
+++ b/docs/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm Deployment
 
 This article introduces the use of `helm` to deploy the `Apache ShenYu` gateway.
 
-Please refer to [Helm Deployment](https://shenyu.apache.org/helm/index/) for details.
+Please refer to [Helm Deployment](https://shenyu.apache.org/helm/) for details.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/deployment/deployment-helm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm部署
 
 本文介绍使用 `helm` 来部署 `Apache ShenYu` 网关。
 
-详见 [Helm 部署](https://shenyu.apache.org/zh/helm/index/)
+详见 [Helm 部署](https://shenyu.apache.org/zh/helm/)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.5.0/deployment/deployment-helm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.5.0/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm部署
 
 本文介绍使用 `helm` 来部署 `Apache ShenYu` 网关。
 
-详见 [Helm 部署](https://shenyu.apache.org/zh/helm/index/)
+详见 [Helm 部署](https://shenyu.apache.org/zh/helm/)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.5.1/deployment/deployment-helm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.5.1/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm部署
 
 本文介绍使用 `helm` 来部署 `Apache ShenYu` 网关。
 
-详见 [Helm 部署](https://shenyu.apache.org/zh/helm/index/)
+详见 [Helm 部署](https://shenyu.apache.org/zh/helm/)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6.0/deployment/deployment-helm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6.0/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm部署
 
 本文介绍使用 `helm` 来部署 `Apache ShenYu` 网关。
 
-详见 [Helm 部署](https://shenyu.apache.org/zh/helm/index/)
+详见 [Helm 部署](https://shenyu.apache.org/zh/helm/)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6.1/deployment/deployment-helm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6.1/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm部署
 
 本文介绍使用 `helm` 来部署 `Apache ShenYu` 网关。
 
-详见 [Helm 部署](https://shenyu.apache.org/zh/helm/index/)
+详见 [Helm 部署](https://shenyu.apache.org/zh/helm/)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.1/deployment/deployment-helm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.1/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm部署
 
 本文介绍使用 `helm` 来部署 `Apache ShenYu` 网关。
 
-详见 [Helm 部署](https://shenyu.apache.org/zh/helm/index/)
+详见 [Helm 部署](https://shenyu.apache.org/zh/helm/)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.2/deployment/deployment-helm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.2/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm部署
 
 本文介绍使用 `helm` 来部署 `Apache ShenYu` 网关。
 
-详见 [Helm 部署](https://shenyu.apache.org/zh/helm/index/)
+详见 [Helm 部署](https://shenyu.apache.org/zh/helm/)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.3/deployment/deployment-helm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.3/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm部署
 
 本文介绍使用 `helm` 来部署 `Apache ShenYu` 网关。
 
-详见 [Helm 部署](https://shenyu.apache.org/zh/helm/index/)
+详见 [Helm 部署](https://shenyu.apache.org/zh/helm/)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0/deployment/deployment-helm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm部署
 
 本文介绍使用 `helm` 来部署 `Apache ShenYu` 网关。
 
-详见 [Helm 部署](https://shenyu.apache.org/zh/helm/index/)
+详见 [Helm 部署](https://shenyu.apache.org/zh/helm/)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7.1/deployment/deployment-helm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7.1/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm部署
 
 本文介绍使用 `helm` 来部署 `Apache ShenYu` 网关。
 
-详见 [Helm 部署](https://shenyu.apache.org/zh/helm/index/)
+详见 [Helm 部署](https://shenyu.apache.org/zh/helm/)

--- a/versioned_docs/version-2.5.0/deployment/deployment-helm.md
+++ b/versioned_docs/version-2.5.0/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm Deployment
 
 This article introduces the use of `helm` to deploy the `Apache ShenYu` gateway.
 
-Please refer to [Helm Deployment](https://shenyu.apache.org/helm/index/) for details.
+Please refer to [Helm Deployment](https://shenyu.apache.org/helm/) for details.

--- a/versioned_docs/version-2.5.1/deployment/deployment-helm.md
+++ b/versioned_docs/version-2.5.1/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm Deployment
 
 This article introduces the use of `helm` to deploy the `Apache ShenYu` gateway.
 
-Please refer to [Helm Deployment](https://shenyu.apache.org/helm/index/) for details.
+Please refer to [Helm Deployment](https://shenyu.apache.org/helm/) for details.

--- a/versioned_docs/version-2.6.0/deployment/deployment-helm.md
+++ b/versioned_docs/version-2.6.0/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm Deployment
 
 This article introduces the use of `helm` to deploy the `Apache ShenYu` gateway.
 
-Please refer to [Helm Deployment](https://shenyu.apache.org/helm/index/) for details.
+Please refer to [Helm Deployment](https://shenyu.apache.org/helm/) for details.

--- a/versioned_docs/version-2.6.1/deployment/deployment-helm.md
+++ b/versioned_docs/version-2.6.1/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm Deployment
 
 This article introduces the use of `helm` to deploy the `Apache ShenYu` gateway.
 
-Please refer to [Helm Deployment](https://shenyu.apache.org/helm/index/) for details.
+Please refer to [Helm Deployment](https://shenyu.apache.org/helm/) for details.

--- a/versioned_docs/version-2.7.0.1/deployment/deployment-helm.md
+++ b/versioned_docs/version-2.7.0.1/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm Deployment
 
 This article introduces the use of `helm` to deploy the `Apache ShenYu` gateway.
 
-Please refer to [Helm Deployment](https://shenyu.apache.org/helm/index/) for details.
+Please refer to [Helm Deployment](https://shenyu.apache.org/helm/) for details.

--- a/versioned_docs/version-2.7.0.2/deployment/deployment-helm.md
+++ b/versioned_docs/version-2.7.0.2/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm Deployment
 
 This article introduces the use of `helm` to deploy the `Apache ShenYu` gateway.
 
-Please refer to [Helm Deployment](https://shenyu.apache.org/helm/index/) for details.
+Please refer to [Helm Deployment](https://shenyu.apache.org/helm/) for details.

--- a/versioned_docs/version-2.7.0.3/deployment/deployment-helm.md
+++ b/versioned_docs/version-2.7.0.3/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm Deployment
 
 This article introduces the use of `helm` to deploy the `Apache ShenYu` gateway.
 
-Please refer to [Helm Deployment](https://shenyu.apache.org/helm/index/) for details.
+Please refer to [Helm Deployment](https://shenyu.apache.org/helm/) for details.

--- a/versioned_docs/version-2.7.0/deployment/deployment-helm.md
+++ b/versioned_docs/version-2.7.0/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm Deployment
 
 This article introduces the use of `helm` to deploy the `Apache ShenYu` gateway.
 
-Please refer to [Helm Deployment](https://shenyu.apache.org/helm/index/) for details.
+Please refer to [Helm Deployment](https://shenyu.apache.org/helm/) for details.

--- a/versioned_docs/version-2.7.1/deployment/deployment-helm.md
+++ b/versioned_docs/version-2.7.1/deployment/deployment-helm.md
@@ -7,4 +7,4 @@ description: Helm Deployment
 
 This article introduces the use of `helm` to deploy the `Apache ShenYu` gateway.
 
-Please refer to [Helm Deployment](https://shenyu.apache.org/helm/index/) for details.
+Please refer to [Helm Deployment](https://shenyu.apache.org/helm/) for details.


### PR DESCRIPTION
All changes:
- 20 files across all versions (v2.5.0 through v2.7.1), covering both docs/ / versioned_docs/ (English) and                              
  i18n/zh/docusaurus-plugin-content-docs/ (Chinese). 