### PR TITLE
docs: fix JWT plugin frontmatter formatting across all versions

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/plugin-center/security/jwt-plugin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/plugin-center/security/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT插件
 keywords: ["JWT"]
 description: JWT插件
-----------------
+---
 
 # 1.概述
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.4.0/plugin-center/authority-and-certification/jwt-plugin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.4.0/plugin-center/authority-and-certification/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT插件
 keywords: ["JWT"]
 description: JWT插件
-----------------
+---
 
 # 1.概述
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.4.1/plugin-center/authority-and-certification/jwt-plugin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.4.1/plugin-center/authority-and-certification/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT插件
 keywords: ["JWT"]
 description: JWT插件
-----------------
+---
 
 # 1.概述
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.4.2/plugin-center/authority-and-certification/jwt-plugin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.4.2/plugin-center/authority-and-certification/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT插件
 keywords: ["JWT"]
 description: JWT插件
-----------------
+---
 
 # 1.概述
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.4.3/plugin-center/authority-and-certification/jwt-plugin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.4.3/plugin-center/authority-and-certification/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT插件
 keywords: ["JWT"]
 description: JWT插件
-----------------
+---
 
 # 1.概述
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.5.0/plugin-center/security/jwt-plugin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.5.0/plugin-center/security/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT插件
 keywords: ["JWT"]
 description: JWT插件
-----------------
+---
 
 # 1.概述
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.5.1/plugin-center/security/jwt-plugin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.5.1/plugin-center/security/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT插件
 keywords: ["JWT"]
 description: JWT插件
-----------------
+---
 
 # 1.概述
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6.0/plugin-center/security/jwt-plugin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6.0/plugin-center/security/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT插件
 keywords: ["JWT"]
 description: JWT插件
-----------------
+---
 
 # 1.概述
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.6.1/plugin-center/security/jwt-plugin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.6.1/plugin-center/security/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT插件
 keywords: ["JWT"]
 description: JWT插件
-----------------
+---
 
 # 1.概述
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.1/plugin-center/security/jwt-plugin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.1/plugin-center/security/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT插件
 keywords: ["JWT"]
 description: JWT插件
-----------------
+---
 
 # 1.概述
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.2/plugin-center/security/jwt-plugin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.2/plugin-center/security/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT插件
 keywords: ["JWT"]
 description: JWT插件
-----------------
+---
 
 # 1.概述
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.3/plugin-center/security/jwt-plugin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.3/plugin-center/security/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT插件
 keywords: ["JWT"]
 description: JWT插件
-----------------
+---
 
 # 1.概述
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0/plugin-center/security/jwt-plugin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7.0/plugin-center/security/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT插件
 keywords: ["JWT"]
 description: JWT插件
-----------------
+---
 
 # 1.概述
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.7.1/plugin-center/security/jwt-plugin.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.7.1/plugin-center/security/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT插件
 keywords: ["JWT"]
 description: JWT插件
-----------------
+---
 
 # 1.概述
 

--- a/versioned_docs/version-2.4.0/plugin-center/authority-and-certification/jwt-plugin.md
+++ b/versioned_docs/version-2.4.0/plugin-center/authority-and-certification/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT plugin
 keywords: ["JWT"]
 description: JWT plugin
-----------------------
+---
 
 # 1. Overview
 

--- a/versioned_docs/version-2.4.1/plugin-center/authority-and-certification/jwt-plugin.md
+++ b/versioned_docs/version-2.4.1/plugin-center/authority-and-certification/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT plugin
 keywords: ["JWT"]
 description: JWT plugin
-----------------------
+---
 
 # 1. Overview
 

--- a/versioned_docs/version-2.4.2/plugin-center/authority-and-certification/jwt-plugin.md
+++ b/versioned_docs/version-2.4.2/plugin-center/authority-and-certification/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT plugin
 keywords: ["JWT"]
 description: JWT plugin
-----------------------
+---
 
 # 1. Overview
 

--- a/versioned_docs/version-2.4.3/plugin-center/authority-and-certification/jwt-plugin.md
+++ b/versioned_docs/version-2.4.3/plugin-center/authority-and-certification/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT plugin
 keywords: ["JWT"]
 description: JWT plugin
-----------------------
+---
 
 # 1. Overview
 

--- a/versioned_docs/version-2.5.0/plugin-center/security/jwt-plugin.md
+++ b/versioned_docs/version-2.5.0/plugin-center/security/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT plugin
 keywords: ["JWT"]
 description: JWT plugin
-----------------------
+---
 
 # 1. Overview
 

--- a/versioned_docs/version-2.5.1/plugin-center/security/jwt-plugin.md
+++ b/versioned_docs/version-2.5.1/plugin-center/security/jwt-plugin.md
@@ -1,9 +1,8 @@
 ---
-
 title: JWT plugin
 keywords: ["JWT"]
 description: JWT plugin
-----------------------
+---
 
 # 1. Overview
 


### PR DESCRIPTION
## Summary

Fixed malformed frontmatter across all 20 JWT plugin documentation files in the project.

## Problem

Each file had two frontmatter issues:

1. A blank line between the opening `---` delimiter and the `title` field
2. A line of dashes used as the closing delimiter instead of `---`

### Before

```yaml

---
title: JWT plugin
keywords: ["JWT"]
description: JWT plugin
-----------------------
```

### After

```yaml
---
title: JWT plugin
keywords: ["JWT"]
description: JWT plugin
---
```

## Affected Files

### Chinese (`i18n/zh/`) — 14 files

| Version | File |
|---|---|
| current | `i18n/zh/docusaurus-plugin-content-docs/current/plugin-center/security/jwt-plugin.md` |
| 2.4.0 | `i18n/zh/docusaurus-plugin-content-docs/version-2.4.0/plugin-center/authority-and-certification/jwt-plugin.md` |
| 2.4.1 | `i18n/zh/docusaurus-plugin-content-docs/version-2.4.1/plugin-center/authority-and-certification/jwt-plugin.md` |
| 2.4.2 | `i18n/zh/docusaurus-plugin-content-docs/version-2.4.2/plugin-center/authority-and-certification/jwt-plugin.md` |
| 2.4.3 | `i18n/zh/docusaurus-plugin-content-docs/version-2.4.3/plugin-center/authority-and-certification/jwt-plugin.md` |
| 2.5.0 | `i18n/zh/docusaurus-plugin-content-docs/version-2.5.0/plugin-center/security/jwt-plugin.md` |
| 2.5.1 | `i18n/zh/docusaurus-plugin-content-docs/version-2.5.1/plugin-center/security/jwt-plugin.md` |
| 2.6.0 | `i18n/zh/docusaurus-plugin-content-docs/version-2.6.0/plugin-center/security/jwt-plugin.md` |
| 2.6.1 | `i18n/zh/docusaurus-plugin-content-docs/version-2.6.1/plugin-center/security/jwt-plugin.md` |
| 2.7.0 | `i18n/zh/docusaurus-plugin-content-docs/version-2.7.0/plugin-center/security/jwt-plugin.md` |
| 2.7.0.1 | `i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.1/plugin-center/security/jwt-plugin.md` |
| 2.7.0.2 | `i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.2/plugin-center/security/jwt-plugin.md` |
| 2.7.0.3 | `i18n/zh/docusaurus-plugin-content-docs/version-2.7.0.3/plugin-center/security/jwt-plugin.md` |
| 2.7.1 | `i18n/zh/docusaurus-plugin-content-docs/version-2.7.1/plugin-center/security/jwt-plugin.md` |

### English (`versioned_docs/`) — 6 files

| Version | File |
|---|---|
| 2.4.0 | `versioned_docs/version-2.4.0/plugin-center/authority-and-certification/jwt-plugin.md` |
| 2.4.1 | `versioned_docs/version-2.4.1/plugin-center/authority-and-certification/jwt-plugin.md` |
| 2.4.2 | `versioned_docs/version-2.4.2/plugin-center/authority-and-certification/jwt-plugin.md` |
| 2.4.3 | `versioned_docs/version-2.4.3/plugin-center/authority-and-certification/jwt-plugin.md` |
| 2.5.0 | `versioned_docs/version-2.5.0/plugin-center/security/jwt-plugin.md` |
| 2.5.1 | `versioned_docs/version-2.5.1/plugin-center/security/jwt-plugin.md` |