### PR TITLE
docs: fix team page GitHub avatar loading

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-pages/team.mdx
+++ b/i18n/zh/docusaurus-plugin-content-pages/team.mdx
@@ -26,207 +26,207 @@ tags: ["Team"]
         <th><b></b></th>
     </tr>
     <tr>
-        <td><a href="http://github.com/yu199195"><img width="64" src="https://avatars.githubusercontent.com/u/9673503?v=4"/></a></td>
+        <td><a href="https://github.com/yu199195"><img width="64" src="https://github.com/yu199195.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Yu Xiao</td>
         <td><a href="https://people.apache.org/committer-index.html#xiaoyu">xiaoyu</a></td>
-        <td><a href="http://github.com/yu199195">yu199195</a></td>
+        <td><a href="https://github.com/yu199195">yu199195</a></td>
         <td>Founder, V.P. and Chair of PMC </td>
         <td><a href="https://twitter.com/yu199195"><img width="32" src="https://shenyu.apache.org/img/community/twitterblue.png"/>yu199195</a></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/tuohai666"><img width="64" src="https://avatars.githubusercontent.com/u/24643893?v=4"/></a></td>
+        <td><a href="https://github.com/tuohai666"><img width="64" src="https://github.com/tuohai666.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Yonglun Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#zhangyonglun">zhangyonglun</a></td>
-        <td><a href="http://github.com/tuohai666">tuohai666</a></td>
+        <td><a href="https://github.com/tuohai666">tuohai666</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/WillemJiang"><img width="64" src="https://avatars.githubusercontent.com/u/219644?v=4"/></a></td>
+        <td><a href="https://github.com/WillemJiang"><img width="64" src="https://github.com/WillemJiang.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Willem Ning Jiang</td>
         <td><a href="https://people.apache.org/committer-index.html#ningjiang">ningjiang</a></td>
-        <td><a href="http://github.com/WillemJiang">WillemJiang</a></td>
+        <td><a href="https://github.com/WillemJiang">WillemJiang</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/justinmclean"><img width="64" src="https://avatars.githubusercontent.com/u/144504?v=4"/></a></td>
+        <td><a href="https://github.com/justinmclean"><img width="64" src="https://github.com/justinmclean.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Justin Mclean</td>
         <td><a href="https://people.apache.org/committer-index.html#jmclean">jmclean</a></td>
-        <td><a href="http://github.com/justinmclean">justinmclean</a></td>
+        <td><a href="https://github.com/justinmclean">justinmclean</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/Apache9"><img width="64" src="https://avatars.githubusercontent.com/u/4958168?v=4"/></a></td>
+        <td><a href="https://github.com/Apache9"><img width="64" src="https://github.com/Apache9.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Duo Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#zhangduo">zhangduo</a></td>
-        <td><a href="http://github.com/Apache9">Apache9</a></td>
+        <td><a href="https://github.com/Apache9">Apache9</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/atris"><img width="64" src="https://avatars.githubusercontent.com/u/1724131?v=4"/></a></td>
+        <td><a href="https://github.com/atris"><img width="64" src="https://github.com/atris.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Atri Sharma</td>
         <td><a href="https://people.apache.org/committer-index.html#atri">atri</a></td>
-        <td><a href="http://github.com/atris">atris</a></td>
+        <td><a href="https://github.com/atris">atris</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/sunjincheng121"><img width="64" src="https://avatars.githubusercontent.com/u/22488084?v=4"/></a></td>
+        <td><a href="https://github.com/sunjincheng121"><img width="64" src="https://github.com/sunjincheng121.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Jincheng Sun</td>
         <td><a href="https://people.apache.org/committer-index.html#jincheng">jincheng</a></td>
-        <td><a href="http://github.com/sunjincheng121">sunjincheng121</a></td>
+        <td><a href="https://github.com/sunjincheng121">sunjincheng121</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/djkevincr"><img width="64" src="https://avatars.githubusercontent.com/u/1346010?v=4"/></a></td>
+        <td><a href="https://github.com/djkevincr"><img width="64" src="https://github.com/djkevincr.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Kevin Ratnasekera</td>
         <td><a href="https://people.apache.org/committer-index.html#djkevincr">djkevincr</a></td>
-        <td><a href="http://github.com/djkevincr">djkevincr</a></td>
+        <td><a href="https://github.com/djkevincr">djkevincr</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/dengliming"><img width="64" src="https://avatars.githubusercontent.com/u/7796156?v=4"/></a></td>
+        <td><a href="https://github.com/dengliming"><img width="64" src="https://github.com/dengliming.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Liming Deng</td>
         <td><a href="https://people.apache.org/committer-index.html#dengliming">dengliming</a></td>
-        <td><a href="http://github.com/dengliming">dengliming</a></td>
+        <td><a href="https://github.com/dengliming">dengliming</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/nuo-promise"><img width="64" src="https://avatars.githubusercontent.com/u/46160170?v=4"/></a></td>
+        <td><a href="https://github.com/nuo-promise"><img width="64" src="https://github.com/nuo-promise.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>JianMing Ding</td>
         <td><a href="https://people.apache.org/committer-index.html#nuoyan">nuoyan</a></td>
-        <td><a href="http://github.com/nuo-promise">nuo-promise</a></td>
+        <td><a href="https://github.com/nuo-promise">nuo-promise</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/tydhot"><img width="64" src="https://avatars.githubusercontent.com/u/27889201?v=4"/></a></td>
+        <td><a href="https://github.com/tydhot"><img width="64" src="https://github.com/tydhot.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Tang Yudong</td>
         <td><a href="https://people.apache.org/committer-index.html#tydhot">tydhot</a></td>
-        <td><a href="http://github.com/tydhot">tydhot</a></td>
+        <td><a href="https://github.com/tydhot">tydhot</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/SaberSola"><img width="64" src="https://avatars.githubusercontent.com/u/24998393?v=4"/></a></td>
+        <td><a href="https://github.com/SaberSola"><img width="64" src="https://github.com/SaberSola.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Lei Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#sabersola">sabersola</a></td>
-        <td><a href="http://github.com/SaberSola">SaberSola</a></td>
+        <td><a href="https://github.com/SaberSola">SaberSola</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/qicz"><img width="64" src="https://avatars.githubusercontent.com/u/2174082?v=4"/></a></td>
+        <td><a href="https://github.com/qicz"><img width="64" src="https://github.com/qicz.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Congqi Zhu</td>
         <td><a href="https://people.apache.org/committer-index.html#qicz">qicz</a></td>
-        <td><a href="http://github.com/qicz">qicz</a></td>
+        <td><a href="https://github.com/qicz">qicz</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/HessTina-YuI"><img width="64" src="https://avatars.githubusercontent.com/u/13451528?v=4"/></a></td>
+        <td><a href="https://github.com/HessTina-YuI"><img width="64" src="https://github.com/HessTina-YuI.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Yi Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#yui">yui</a></td>
-        <td><a href="http://github.com/HessTina-YuI">HessTina-YuI</a></td>
+        <td><a href="https://github.com/HessTina-YuI">HessTina-YuI</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/loongs-zhang"><img width="64" src="https://avatars.githubusercontent.com/u/38336731?v=4"/></a></td>
+        <td><a href="https://github.com/loongs-zhang"><img width="64" src="https://github.com/loongs-zhang.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>ZiCheng Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#zhangzicheng">zhangzicheng</a></td>
-        <td><a href="http://github.com/loongs-zhang">dragon-zhang</a></td>
+        <td><a href="https://github.com/loongs-zhang">dragon-zhang</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/JooKS-me"><img width="64" src="https://avatars.githubusercontent.com/u/62384022?v=4"/></a></td>
+        <td><a href="https://github.com/JooKS-me"><img width="64" src="https://github.com/JooKS-me.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Kunshuai Zhu</td>
         <td><a href="https://people.apache.org/committer-index.html#jooks">jooks</a></td>
-        <td><a href="http://github.com/JooKS-me">JooKS-me</a></td>
+        <td><a href="https://github.com/JooKS-me">JooKS-me</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/midnight2104"><img width="64" src="https://avatars.githubusercontent.com/u/13334620?v=4"/></a></td>
+        <td><a href="https://github.com/midnight2104"><img width="64" src="https://github.com/midnight2104.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Liang Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#midnight2104">midnight2104</a></td>
-        <td><a href="http://github.com/midnight2104">midnight2104</a></td>
+        <td><a href="https://github.com/midnight2104">midnight2104</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/li-keguo"><img width="64" src="https://avatars.githubusercontent.com/u/33576070?v=4"/></a></td>
+        <td><a href="https://github.com/li-keguo"><img width="64" src="https://github.com/li-keguo.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Keguo Li</td>
         <td><a href="https://people.apache.org/committer-index.html#likeguo">likeguo</a></td>
-        <td><a href="http://github.com/li-keguo">li-keguo</a></td>
+        <td><a href="https://github.com/li-keguo">li-keguo</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/impactCn"><img width="64" src="https://avatars.githubusercontent.com/u/35489877?v=4"/></a></td>
+        <td><a href="https://github.com/impactCn"><img width="64" src="https://github.com/impactCn.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>SiYing Zheng</td>
         <td><a href="https://people.apache.org/committer-index.html#impactcn">impactcn</a></td>
-        <td><a href="http://github.com/impactCn">impactCn</a></td>
+        <td><a href="https://github.com/impactCn">impactCn</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/KevinClair"><img width="64" src="https://avatars.githubusercontent.com/u/37257651?v=4"/></a></td>
+        <td><a href="https://github.com/KevinClair"><img width="64" src="https://github.com/KevinClair.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>MingJie Song</td>
         <td><a href="https://people.apache.org/committer-index.html#kevinclair">kevinclair</a></td>
-        <td><a href="http://github.com/KevinClair">KevinClair</a></td>
+        <td><a href="https://github.com/KevinClair">KevinClair</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/fengzhenbing"><img width="64" src="https://avatars.githubusercontent.com/u/4169359?v=4"/></a></td>
+        <td><a href="https://github.com/fengzhenbing"><img width="64" src="https://github.com/fengzhenbing.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Zhenbing Feng</td>
         <td><a href="https://people.apache.org/committer-index.html#fengzhenbing">fengzhenbing</a></td>
-        <td><a href="http://github.com/fengzhenbing">fengzhenbing</a></td>
+        <td><a href="https://github.com/fengzhenbing">fengzhenbing</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/asxing"><img width="64" src="https://avatars.githubusercontent.com/u/22816271?v=4"/></a></td>
+        <td><a href="https://github.com/asxing"><img width="64" src="https://github.com/asxing.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Asxing</td>
         <td><a href="https://people.apache.org/committer-index.html#asxing">asxing</a></td>
-        <td><a href="http://github.com/asxing">asxing</a></td>
+        <td><a href="https://github.com/asxing">asxing</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/lw1243925457"><img width="64" src="https://avatars.githubusercontent.com/u/11513436?v=4"/></a></td>
+        <td><a href="https://github.com/lw1243925457"><img width="64" src="https://github.com/lw1243925457.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Wei Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#lw1243925457">lw1243925457</a></td>
-        <td><a href="http://github.com/lw1243925457">lw1243925457</a></td>
+        <td><a href="https://github.com/lw1243925457">lw1243925457</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/moremind"><img width="64" src="https://avatars.githubusercontent.com/u/20184263?v=4"/></a></td>
+        <td><a href="https://github.com/moremind"><img width="64" src="https://github.com/moremind.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Fengen He</td>
         <td><a href="https://people.apache.org/committer-index.html#hefengen">hefengen</a></td>
-        <td><a href="http://github.com/moremind">moremind</a></td>
+        <td><a href="https://github.com/moremind">moremind</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/yunlongn"><img width="64" src="https://avatars.githubusercontent.com/u/38271111?v=4"/></a></td>
+        <td><a href="https://github.com/yunlongn"><img width="64" src="https://github.com/yunlongn.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Yunlong Lee</td>
         <td><a href="https://people.apache.org/committer-index.html#yunlong">yunlong</a></td>
-        <td><a href="http://github.com/yunlongn">yunlongn</a></td>
+        <td><a href="https://github.com/yunlongn">yunlongn</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/aias00"><img width="64" src="https://avatars.githubusercontent.com/u/25810623?v=4"/></a></td>
+        <td><a href="https://github.com/aias00"><img width="64" src="https://github.com/aias00.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Hongyu Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#liuhongyu">liuhongyu</a></td>
         <td><a href="https://github.com/aias00">liuhongyu</a></td>
@@ -234,215 +234,215 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/prFor"><img width="64" src="https://avatars.githubusercontent.com/u/4089611?v=4"/></a></td>
+        <td><a href="https://github.com/prFor"><img width="64" src="https://github.com/prFor.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Bin Chen</td>
         <td><a href="https://people.apache.org/committer-index.html#sixh">sixh</a></td>
-        <td><a href="http://github.com/prFor">prFor</a></td>
+        <td><a href="https://github.com/prFor">prFor</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/haibo-duan"><img width="64" src="https://avatars.githubusercontent.com/u/7974845?v=4"/></a></td>
+        <td><a href="https://github.com/haibo-duan"><img width="64" src="https://github.com/haibo-duan.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Haibo Duan</td>
         <td><a href="https://people.apache.org/committer-index.html#haiboduan">haiboduan</a></td>
-        <td><a href="http://github.com/haibo-duan">haibo-duan</a></td>
+        <td><a href="https://github.com/haibo-duan">haibo-duan</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/renzhuyan"><img width="64" src="https://avatars.githubusercontent.com/u/21033025?v=4"/></a></td>
+        <td><a href="https://github.com/renzhuyan"><img width="64" src="https://github.com/renzhuyan.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>RenZhu Yan</td>
         <td><a href="https://people.apache.org/committer-index.html#renzhuyan">renzhuyan</a></td>
-        <td><a href="http://github.com/renzhuyan">renzhuyan</a></td>
+        <td><a href="https://github.com/renzhuyan">renzhuyan</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/hgaol"><img width="64" src="https://avatars.githubusercontent.com/u/11908658?v=4"/></a></td>
+        <td><a href="https://github.com/hgaol"><img width="64" src="https://github.com/hgaol.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Han Gao</td>
         <td><a href="https://people.apache.org/committer-index.html#gaohan">gaohan</a></td>
-        <td><a href="http://github.com/hgaol">hgaol</a></td>
+        <td><a href="https://github.com/hgaol">hgaol</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/hutaishi"><img width="64" src="https://avatars.githubusercontent.com/u/12478263?v=4"/></a></td>
+        <td><a href="https://github.com/hutaishi"><img width="64" src="https://github.com/hutaishi.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>TaiShi Hu</td>
         <td><a href="https://people.apache.org/committer-index.html#hutaishi">hutaishi</a></td>
-        <td><a href="http://github.com/hutaishi">hutaishi</a></td>
+        <td><a href="https://github.com/hutaishi">hutaishi</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/daiwenyu"><img width="64" src="https://avatars.githubusercontent.com/u/16659386?v=4"/></a></td>
+        <td><a href="https://github.com/daiwenyu"><img width="64" src="https://github.com/daiwenyu.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>WenYu Dai</td>
         <td><a href="https://people.apache.org/committer-index.html#dayu">dayu</a></td>
-        <td><a href="http://github.com/daiwenyu">daiwenyu</a></td>
+        <td><a href="https://github.com/daiwenyu">daiwenyu</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/lxl910128"><img width="64" src="https://avatars.githubusercontent.com/u/8736745?v=4"/></a></td>
+        <td><a href="https://github.com/lxl910128"><img width="64" src="https://github.com/lxl910128.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>XiaoLong Luo</td>
         <td><a href="https://people.apache.org/committer-index.html#luoxiaolong">luoxiaolong</a></td>
-        <td><a href="http://github.com/lxl910128">lxl910128</a></td>
+        <td><a href="https://github.com/lxl910128">lxl910128</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/ttttangzhen"><img width="64" src="https://avatars.githubusercontent.com/u/74766688?v=4"/></a></td>
+        <td><a href="https://github.com/ttttangzhen"><img width="64" src="https://github.com/ttttangzhen.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Zhen Tang</td>
         <td><a href="https://people.apache.org/committer-index.html#alextang">alextang</a></td>
-        <td><a href="http://github.com/ttttangzhen">ttttangzhen</a></td>
+        <td><a href="https://github.com/ttttangzhen">ttttangzhen</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/fightingting"><img width="64" src="https://avatars.githubusercontent.com/u/31699402?v=4"/></a></td>
+        <td><a href="https://github.com/fightingting"><img width="64" src="https://github.com/fightingting.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>TingTing Wang</td>
         <td><a href="https://people.apache.org/committer-index.html#fightingting">fightingting</a></td>
-        <td><a href="http://github.com/fightingting">fightingting</a></td>
+        <td><a href="https://github.com/fightingting">fightingting</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/kimmking"><img width="64" src="https://avatars.githubusercontent.com/u/807508?v=4"/></a></td>
+        <td><a href="https://github.com/kimmking"><img width="64" src="https://github.com/kimmking.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Kimm King</td>
         <td><a href="https://people.apache.org/committer-index.html#kimmking">kimmking</a></td>
-        <td><a href="http://github.com/kimmking">kimmking</a></td>
+        <td><a href="https://github.com/kimmking">kimmking</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/0x12FD16B"><img width="64" src="https://avatars.githubusercontent.com/u/8335369?v=4"/></a></td>
+        <td><a href="https://github.com/0x12FD16B"><img width="64" src="https://github.com/0x12FD16B.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>David Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#hex12fd16b">hex12fd16b</a></td>
-        <td><a href="http://github.com/0x12FD16B">0x12FD16B</a></td>
+        <td><a href="https://github.com/0x12FD16B">0x12FD16B</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/huangxfchn"><img width="64" src="https://avatars.githubusercontent.com/u/17267069?v=4"/></a></td>
+        <td><a href="https://github.com/huangxfchn"><img width="64" src="https://github.com/huangxfchn.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>XiaoFeng Huang</td>
         <td><a href="https://people.apache.org/committer-index.html#huangxfchn">huangxfchn</a></td>
-        <td><a href="http://github.com/huangxfchn">huangxfchn</a></td>
+        <td><a href="https://github.com/huangxfchn">huangxfchn</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/xlgm"><img width="64" src="https://avatars.githubusercontent.com/u/11422929?v=4"/></a></td>
+        <td><a href="https://github.com/xlgm"><img width="64" src="https://github.com/xlgm.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Meng Gao</td>
         <td><a href="https://people.apache.org/committer-index.html#zjntgao">zjntgao</a></td>
-        <td><a href="http://github.com/xlgm">xlgm</a></td>
+        <td><a href="https://github.com/xlgm">xlgm</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/SteNicholas"><img width="64" src="https://avatars.githubusercontent.com/u/10048174?v=4"/></a></td>
+        <td><a href="https://github.com/SteNicholas"><img width="64" src="https://github.com/SteNicholas.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Nicholas Jiang</td>
         <td><a href="https://people.apache.org/committer-index.html#nicholasjiang">nicholasjiang</a></td>
-        <td><a href="http://github.com/SteNicholas">SteNicholas</a></td>
+        <td><a href="https://github.com/SteNicholas">SteNicholas</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/ccloomi"><img width="64" src="https://avatars.githubusercontent.com/u/8596174?v=4"/></a></td>
+        <td><a href="https://github.com/ccloomi"><img width="64" src="https://github.com/ccloomi.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Xianjun Chen</td>
         <td><a href="https://people.apache.org/committer-index.html#ccloomi">ccloomi</a></td>
-        <td><a href="http://github.com/ccloomi">ccloomi</a></td>
+        <td><a href="https://github.com/ccloomi">ccloomi</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/lishuo5263"><img width="64" src="https://avatars.githubusercontent.com/u/19170961?v=4"/></a></td>
+        <td><a href="https://github.com/lishuo5263"><img width="64" src="https://github.com/lishuo5263.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Shuo Li</td>
         <td><a href="https://people.apache.org/committer-index.html#lishuo">lishuo</a></td>
-        <td><a href="http://github.com/lishuo5263">lishuo5263</a></td>
+        <td><a href="https://github.com/lishuo5263">lishuo5263</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/lahmxu"><img width="64" src="https://avatars.githubusercontent.com/u/31627887?v=4"/></a></td>
+        <td><a href="https://github.com/lahmxu"><img width="64" src="https://github.com/lahmxu.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Jun Xu</td>
         <td><a href="https://people.apache.org/committer-index.html#lahmxu">lahmxu</a></td>
-        <td><a href="http://github.com/lahmxu">lahmxu</a></td>
+        <td><a href="https://github.com/lahmxu">lahmxu</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/zhc00"><img width="64" src="https://avatars.githubusercontent.com/u/104989765?v=4"/></a></td>
+        <td><a href="https://github.com/zhc00"><img width="64" src="https://github.com/zhc00.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Haochao Zhuang</td>
         <td><a href="https://people.apache.org/committer-index.html#daming">daming</a></td>
-        <td><a href="http://github.com/zhc00">zhc00</a></td>
+        <td><a href="https://github.com/zhc00">zhc00</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-         <td><a href="http://github.com/mahaitao617"><img width="64" src="https://avatars.githubusercontent.com/u/12776225?v=4"/></a></td>
+         <td><a href="https://github.com/mahaitao617"><img width="64" src="https://github.com/mahaitao617.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
          <td>mahaitao</td>
          <td><a href="https://people.apache.org/committer-index.html#mahaitao">mahaitao</a></td>
-         <td><a href="http://github.com/mahaitao617">mahaitao617</a></td>
+         <td><a href="https://github.com/mahaitao617">mahaitao617</a></td>
          <td>Committer</td>
          <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/ShawnJim"><img width="64" src="https://avatars.githubusercontent.com/u/32192263?v=4"/></a></td>
+        <td><a href="https://github.com/ShawnJim"><img width="64" src="https://github.com/ShawnJim.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Zhenxiao Jin</td>
         <td><a href="https://people.apache.org/committer-index.html#jinzhenxiao">jinzhenxiao</a></td>
-        <td><a href="http://github.com/ShawnJim">Shawn Jim</a></td>
+        <td><a href="https://github.com/ShawnJim">Shawn Jim</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/tian-pengfei"><img width="64" src="https://avatars.githubusercontent.com/u/42602026?s=96&v=4"/></a></td>
+        <td><a href="https://github.com/tian-pengfei"><img width="64" src="https://github.com/tian-pengfei.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Pengfei Tian</td>
         <td><a href="https://people.apache.org/committer-index.html#tianpengfei">tianpengfei</a></td>
-        <td><a href="http://github.com/tian-pengfei">tian-pengfei</a></td>
+        <td><a href="https://github.com/tian-pengfei">tian-pengfei</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/HaiqiQin"><img width="64" src="https://avatars.githubusercontent.com/u/80969210?v=4"/></a></td>
+        <td><a href="https://github.com/HaiqiQin"><img width="64" src="https://github.com/HaiqiQin.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Haiqi Qin</td>
         <td><a href="https://people.apache.org/committer-index.html#haiqi">haiqi</a></td>
-        <td><a href="http://github.com/HaiqiQin">HaiqiQin</a></td>
+        <td><a href="https://github.com/HaiqiQin">HaiqiQin</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/847850277"><img width="64" src="https://avatars.githubusercontent.com/u/12622645?v=4"/></a></td>
+        <td><a href="https://github.com/847850277"><img width="64" src="https://github.com/847850277.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Peng Zheng</td>
         <td><a href="https://people.apache.org/committer-index.html#penzheng">penzheng</a></td>
-        <td><a href="http://github.com/847850277">847850277</a></td>
+        <td><a href="https://github.com/847850277">847850277</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/lianjunwei"><img width="64" src="https://avatars.githubusercontent.com/u/13819823?v=4"/></a></td>
+        <td><a href="https://github.com/lianjunwei"><img width="64" src="https://github.com/lianjunwei.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Junwei Lian</td>
         <td><a href="https://people.apache.org/committer-index.html#lianjunwei">lianjunwei</a></td>
-        <td><a href="http://github.com/lianjunwei">lianjunwei</a></td>
+        <td><a href="https://github.com/lianjunwei">lianjunwei</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/damonxue"><img width="64" src="https://avatars.githubusercontent.com/u/49482363?v=4"/></a></td>
+        <td><a href="https://github.com/damonxue"><img width="64" src="https://github.com/damonxue.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Damon Xue</td>
         <td><a href="https://people.apache.org/committer-index.html#xuehuilang">xuehuilang</a></td>
-        <td><a href="http://github.com/damonxue">xuehuilang</a></td>
+        <td><a href="https://github.com/damonxue">xuehuilang</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/misaya295"><img width="64" src="https://avatars.githubusercontent.com/u/45778734?v=4"/></a></td>
+        <td><a href="https://github.com/misaya295"><img width="64" src="https://github.com/misaya295.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Wenkang Chen</td>
         <td><a href="https://people.apache.org/committer-index.html#chenwenkang">chenwenkang</a></td>
-        <td><a href="http://github.com/misaya295">chenwenkang</a></td>
+        <td><a href="https://github.com/misaya295">chenwenkang</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/kerwin612"><img width="64" src="https://avatars.githubusercontent.com/u/3371163?v=4"/></a></td>
+        <td><a href="https://github.com/kerwin612"><img width="64" src="https://github.com/kerwin612.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Le Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#kerwin612">kerwin612</a></td>
         <td><a href="https://github.com/kerwin612">kerwin612</a></td>
@@ -450,7 +450,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/VampireAchao"><img width="64" src="https://avatars.githubusercontent.com/u/52746628?v=4"/></a></td>
+        <td><a href="https://github.com/VampireAchao"><img width="64" src="https://github.com/VampireAchao.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>achao</td>
         <td><a href="https://people.apache.org/committer-index.html#achao">achao</a></td>
         <td><a href="https://github.com/VampireAchao">achao</a></td>
@@ -458,7 +458,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/xcsnx"><img width="64" src="https://avatars.githubusercontent.com/u/47652067?v=4"/></a></td>
+        <td><a href="https://github.com/xcsnx"><img width="64" src="https://github.com/xcsnx.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>xcsnx</td>
         <td><a href="https://people.apache.org/committer-index.html#xcsnx">xcsnx</a></td>
         <td><a href="https://github.com/xcsnx">xcsnx</a></td>
@@ -466,7 +466,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/yuluo-yx"><img width="64" src="https://avatars.githubusercontent.com/u/77964041?v=4"/></a></td>
+        <td><a href="https://github.com/yuluo-yx"><img width="64" src="https://github.com/yuluo-yx.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>yuluo-yx</td>
         <td><a href="https://people.apache.org/committer-index.html#xcsnx">yuluo-yx</a></td>
         <td><a href="https://github.com/yuluo-yx">yuluo-yx</a></td>
@@ -474,7 +474,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/Wweiei"><img width="64" src="https://avatars.githubusercontent.com/u/45253632?v=4"/></a></td>
+        <td><a href="https://github.com/Wweiei"><img width="64" src="https://github.com/Wweiei.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Wei Wei</td>
         <td><a href="https://people.apache.org/committer-index.html#weiwei">weiwei</a></td>
         <td><a href="https://github.com/Wweiei">Wweiei</a></td>

--- a/i18n/zh/docusaurus-plugin-content-pages/team.mdx
+++ b/i18n/zh/docusaurus-plugin-content-pages/team.mdx
@@ -7,6 +7,7 @@ categories: "Apache ShenYu"
 tags: ["Team"]
 ---
 
+import GitHubAvatar from "@site/src/components/GitHubAvatar";
 
 ## Apache ShenYu 团队
 
@@ -26,7 +27,7 @@ tags: ["Team"]
         <th><b></b></th>
     </tr>
     <tr>
-        <td><a href="https://github.com/yu199195"><img width="64" src="https://github.com/yu199195.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/yu199195"><GitHubAvatar username="yu199195" size={64} /></a></td>
         <td>Yu Xiao</td>
         <td><a href="https://people.apache.org/committer-index.html#xiaoyu">xiaoyu</a></td>
         <td><a href="https://github.com/yu199195">yu199195</a></td>
@@ -34,7 +35,7 @@ tags: ["Team"]
         <td><a href="https://twitter.com/yu199195"><img width="32" src="https://shenyu.apache.org/img/community/twitterblue.png"/>yu199195</a></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/tuohai666"><img width="64" src="https://github.com/tuohai666.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/tuohai666"><GitHubAvatar username="tuohai666" size={64} /></a></td>
         <td>Yonglun Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#zhangyonglun">zhangyonglun</a></td>
         <td><a href="https://github.com/tuohai666">tuohai666</a></td>
@@ -42,7 +43,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/WillemJiang"><img width="64" src="https://github.com/WillemJiang.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/WillemJiang"><GitHubAvatar username="WillemJiang" size={64} /></a></td>
         <td>Willem Ning Jiang</td>
         <td><a href="https://people.apache.org/committer-index.html#ningjiang">ningjiang</a></td>
         <td><a href="https://github.com/WillemJiang">WillemJiang</a></td>
@@ -50,7 +51,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/justinmclean"><img width="64" src="https://github.com/justinmclean.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/justinmclean"><GitHubAvatar username="justinmclean" size={64} /></a></td>
         <td>Justin Mclean</td>
         <td><a href="https://people.apache.org/committer-index.html#jmclean">jmclean</a></td>
         <td><a href="https://github.com/justinmclean">justinmclean</a></td>
@@ -58,7 +59,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/Apache9"><img width="64" src="https://github.com/Apache9.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/Apache9"><GitHubAvatar username="Apache9" size={64} /></a></td>
         <td>Duo Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#zhangduo">zhangduo</a></td>
         <td><a href="https://github.com/Apache9">Apache9</a></td>
@@ -66,7 +67,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/atris"><img width="64" src="https://github.com/atris.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/atris"><GitHubAvatar username="atris" size={64} /></a></td>
         <td>Atri Sharma</td>
         <td><a href="https://people.apache.org/committer-index.html#atri">atri</a></td>
         <td><a href="https://github.com/atris">atris</a></td>
@@ -74,7 +75,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/sunjincheng121"><img width="64" src="https://github.com/sunjincheng121.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/sunjincheng121"><GitHubAvatar username="sunjincheng121" size={64} /></a></td>
         <td>Jincheng Sun</td>
         <td><a href="https://people.apache.org/committer-index.html#jincheng">jincheng</a></td>
         <td><a href="https://github.com/sunjincheng121">sunjincheng121</a></td>
@@ -82,7 +83,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/djkevincr"><img width="64" src="https://github.com/djkevincr.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/djkevincr"><GitHubAvatar username="djkevincr" size={64} /></a></td>
         <td>Kevin Ratnasekera</td>
         <td><a href="https://people.apache.org/committer-index.html#djkevincr">djkevincr</a></td>
         <td><a href="https://github.com/djkevincr">djkevincr</a></td>
@@ -90,7 +91,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/dengliming"><img width="64" src="https://github.com/dengliming.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/dengliming"><GitHubAvatar username="dengliming" size={64} /></a></td>
         <td>Liming Deng</td>
         <td><a href="https://people.apache.org/committer-index.html#dengliming">dengliming</a></td>
         <td><a href="https://github.com/dengliming">dengliming</a></td>
@@ -98,7 +99,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/nuo-promise"><img width="64" src="https://github.com/nuo-promise.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/nuo-promise"><GitHubAvatar username="nuo-promise" size={64} /></a></td>
         <td>JianMing Ding</td>
         <td><a href="https://people.apache.org/committer-index.html#nuoyan">nuoyan</a></td>
         <td><a href="https://github.com/nuo-promise">nuo-promise</a></td>
@@ -106,7 +107,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/tydhot"><img width="64" src="https://github.com/tydhot.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/tydhot"><GitHubAvatar username="tydhot" size={64} /></a></td>
         <td>Tang Yudong</td>
         <td><a href="https://people.apache.org/committer-index.html#tydhot">tydhot</a></td>
         <td><a href="https://github.com/tydhot">tydhot</a></td>
@@ -114,7 +115,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/SaberSola"><img width="64" src="https://github.com/SaberSola.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/SaberSola"><GitHubAvatar username="SaberSola" size={64} /></a></td>
         <td>Lei Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#sabersola">sabersola</a></td>
         <td><a href="https://github.com/SaberSola">SaberSola</a></td>
@@ -122,7 +123,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/qicz"><img width="64" src="https://github.com/qicz.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/qicz"><GitHubAvatar username="qicz" size={64} /></a></td>
         <td>Congqi Zhu</td>
         <td><a href="https://people.apache.org/committer-index.html#qicz">qicz</a></td>
         <td><a href="https://github.com/qicz">qicz</a></td>
@@ -130,7 +131,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/HessTina-YuI"><img width="64" src="https://github.com/HessTina-YuI.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/HessTina-YuI"><GitHubAvatar username="HessTina-YuI" size={64} /></a></td>
         <td>Yi Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#yui">yui</a></td>
         <td><a href="https://github.com/HessTina-YuI">HessTina-YuI</a></td>
@@ -138,7 +139,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/loongs-zhang"><img width="64" src="https://github.com/loongs-zhang.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/loongs-zhang"><GitHubAvatar username="loongs-zhang" size={64} /></a></td>
         <td>ZiCheng Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#zhangzicheng">zhangzicheng</a></td>
         <td><a href="https://github.com/loongs-zhang">dragon-zhang</a></td>
@@ -146,7 +147,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/JooKS-me"><img width="64" src="https://github.com/JooKS-me.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/JooKS-me"><GitHubAvatar username="JooKS-me" size={64} /></a></td>
         <td>Kunshuai Zhu</td>
         <td><a href="https://people.apache.org/committer-index.html#jooks">jooks</a></td>
         <td><a href="https://github.com/JooKS-me">JooKS-me</a></td>
@@ -154,7 +155,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/midnight2104"><img width="64" src="https://github.com/midnight2104.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/midnight2104"><GitHubAvatar username="midnight2104" size={64} /></a></td>
         <td>Liang Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#midnight2104">midnight2104</a></td>
         <td><a href="https://github.com/midnight2104">midnight2104</a></td>
@@ -162,7 +163,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/li-keguo"><img width="64" src="https://github.com/li-keguo.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/li-keguo"><GitHubAvatar username="li-keguo" size={64} /></a></td>
         <td>Keguo Li</td>
         <td><a href="https://people.apache.org/committer-index.html#likeguo">likeguo</a></td>
         <td><a href="https://github.com/li-keguo">li-keguo</a></td>
@@ -170,7 +171,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/impactCn"><img width="64" src="https://github.com/impactCn.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/impactCn"><GitHubAvatar username="impactCn" size={64} /></a></td>
         <td>SiYing Zheng</td>
         <td><a href="https://people.apache.org/committer-index.html#impactcn">impactcn</a></td>
         <td><a href="https://github.com/impactCn">impactCn</a></td>
@@ -178,7 +179,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/KevinClair"><img width="64" src="https://github.com/KevinClair.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/KevinClair"><GitHubAvatar username="KevinClair" size={64} /></a></td>
         <td>MingJie Song</td>
         <td><a href="https://people.apache.org/committer-index.html#kevinclair">kevinclair</a></td>
         <td><a href="https://github.com/KevinClair">KevinClair</a></td>
@@ -186,7 +187,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/fengzhenbing"><img width="64" src="https://github.com/fengzhenbing.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/fengzhenbing"><GitHubAvatar username="fengzhenbing" size={64} /></a></td>
         <td>Zhenbing Feng</td>
         <td><a href="https://people.apache.org/committer-index.html#fengzhenbing">fengzhenbing</a></td>
         <td><a href="https://github.com/fengzhenbing">fengzhenbing</a></td>
@@ -194,7 +195,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/asxing"><img width="64" src="https://github.com/asxing.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/asxing"><GitHubAvatar username="asxing" size={64} /></a></td>
         <td>Asxing</td>
         <td><a href="https://people.apache.org/committer-index.html#asxing">asxing</a></td>
         <td><a href="https://github.com/asxing">asxing</a></td>
@@ -202,7 +203,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/lw1243925457"><img width="64" src="https://github.com/lw1243925457.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/lw1243925457"><GitHubAvatar username="lw1243925457" size={64} /></a></td>
         <td>Wei Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#lw1243925457">lw1243925457</a></td>
         <td><a href="https://github.com/lw1243925457">lw1243925457</a></td>
@@ -210,7 +211,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/moremind"><img width="64" src="https://github.com/moremind.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/moremind"><GitHubAvatar username="moremind" size={64} /></a></td>
         <td>Fengen He</td>
         <td><a href="https://people.apache.org/committer-index.html#hefengen">hefengen</a></td>
         <td><a href="https://github.com/moremind">moremind</a></td>
@@ -218,7 +219,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/yunlongn"><img width="64" src="https://github.com/yunlongn.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/yunlongn"><GitHubAvatar username="yunlongn" size={64} /></a></td>
         <td>Yunlong Lee</td>
         <td><a href="https://people.apache.org/committer-index.html#yunlong">yunlong</a></td>
         <td><a href="https://github.com/yunlongn">yunlongn</a></td>
@@ -226,7 +227,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/aias00"><img width="64" src="https://github.com/aias00.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/aias00"><GitHubAvatar username="aias00" size={64} /></a></td>
         <td>Hongyu Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#liuhongyu">liuhongyu</a></td>
         <td><a href="https://github.com/aias00">liuhongyu</a></td>
@@ -234,7 +235,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/prFor"><img width="64" src="https://github.com/prFor.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/prFor"><GitHubAvatar username="prFor" size={64} /></a></td>
         <td>Bin Chen</td>
         <td><a href="https://people.apache.org/committer-index.html#sixh">sixh</a></td>
         <td><a href="https://github.com/prFor">prFor</a></td>
@@ -242,7 +243,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/haibo-duan"><img width="64" src="https://github.com/haibo-duan.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/haibo-duan"><GitHubAvatar username="haibo-duan" size={64} /></a></td>
         <td>Haibo Duan</td>
         <td><a href="https://people.apache.org/committer-index.html#haiboduan">haiboduan</a></td>
         <td><a href="https://github.com/haibo-duan">haibo-duan</a></td>
@@ -250,7 +251,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/renzhuyan"><img width="64" src="https://github.com/renzhuyan.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/renzhuyan"><GitHubAvatar username="renzhuyan" size={64} /></a></td>
         <td>RenZhu Yan</td>
         <td><a href="https://people.apache.org/committer-index.html#renzhuyan">renzhuyan</a></td>
         <td><a href="https://github.com/renzhuyan">renzhuyan</a></td>
@@ -258,7 +259,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/hgaol"><img width="64" src="https://github.com/hgaol.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/hgaol"><GitHubAvatar username="hgaol" size={64} /></a></td>
         <td>Han Gao</td>
         <td><a href="https://people.apache.org/committer-index.html#gaohan">gaohan</a></td>
         <td><a href="https://github.com/hgaol">hgaol</a></td>
@@ -266,7 +267,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/hutaishi"><img width="64" src="https://github.com/hutaishi.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/hutaishi"><GitHubAvatar username="hutaishi" size={64} /></a></td>
         <td>TaiShi Hu</td>
         <td><a href="https://people.apache.org/committer-index.html#hutaishi">hutaishi</a></td>
         <td><a href="https://github.com/hutaishi">hutaishi</a></td>
@@ -274,7 +275,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/daiwenyu"><img width="64" src="https://github.com/daiwenyu.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/daiwenyu"><GitHubAvatar username="daiwenyu" size={64} /></a></td>
         <td>WenYu Dai</td>
         <td><a href="https://people.apache.org/committer-index.html#dayu">dayu</a></td>
         <td><a href="https://github.com/daiwenyu">daiwenyu</a></td>
@@ -282,7 +283,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/lxl910128"><img width="64" src="https://github.com/lxl910128.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/lxl910128"><GitHubAvatar username="lxl910128" size={64} /></a></td>
         <td>XiaoLong Luo</td>
         <td><a href="https://people.apache.org/committer-index.html#luoxiaolong">luoxiaolong</a></td>
         <td><a href="https://github.com/lxl910128">lxl910128</a></td>
@@ -290,7 +291,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/ttttangzhen"><img width="64" src="https://github.com/ttttangzhen.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/ttttangzhen"><GitHubAvatar username="ttttangzhen" size={64} /></a></td>
         <td>Zhen Tang</td>
         <td><a href="https://people.apache.org/committer-index.html#alextang">alextang</a></td>
         <td><a href="https://github.com/ttttangzhen">ttttangzhen</a></td>
@@ -298,7 +299,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/fightingting"><img width="64" src="https://github.com/fightingting.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/fightingting"><GitHubAvatar username="fightingting" size={64} /></a></td>
         <td>TingTing Wang</td>
         <td><a href="https://people.apache.org/committer-index.html#fightingting">fightingting</a></td>
         <td><a href="https://github.com/fightingting">fightingting</a></td>
@@ -306,7 +307,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/kimmking"><img width="64" src="https://github.com/kimmking.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/kimmking"><GitHubAvatar username="kimmking" size={64} /></a></td>
         <td>Kimm King</td>
         <td><a href="https://people.apache.org/committer-index.html#kimmking">kimmking</a></td>
         <td><a href="https://github.com/kimmking">kimmking</a></td>
@@ -314,7 +315,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/0x12FD16B"><img width="64" src="https://github.com/0x12FD16B.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/0x12FD16B"><GitHubAvatar username="0x12FD16B" size={64} /></a></td>
         <td>David Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#hex12fd16b">hex12fd16b</a></td>
         <td><a href="https://github.com/0x12FD16B">0x12FD16B</a></td>
@@ -322,7 +323,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/huangxfchn"><img width="64" src="https://github.com/huangxfchn.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/huangxfchn"><GitHubAvatar username="huangxfchn" size={64} /></a></td>
         <td>XiaoFeng Huang</td>
         <td><a href="https://people.apache.org/committer-index.html#huangxfchn">huangxfchn</a></td>
         <td><a href="https://github.com/huangxfchn">huangxfchn</a></td>
@@ -330,7 +331,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/xlgm"><img width="64" src="https://github.com/xlgm.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/xlgm"><GitHubAvatar username="xlgm" size={64} /></a></td>
         <td>Meng Gao</td>
         <td><a href="https://people.apache.org/committer-index.html#zjntgao">zjntgao</a></td>
         <td><a href="https://github.com/xlgm">xlgm</a></td>
@@ -338,7 +339,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/SteNicholas"><img width="64" src="https://github.com/SteNicholas.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/SteNicholas"><GitHubAvatar username="SteNicholas" size={64} /></a></td>
         <td>Nicholas Jiang</td>
         <td><a href="https://people.apache.org/committer-index.html#nicholasjiang">nicholasjiang</a></td>
         <td><a href="https://github.com/SteNicholas">SteNicholas</a></td>
@@ -346,7 +347,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/ccloomi"><img width="64" src="https://github.com/ccloomi.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/ccloomi"><GitHubAvatar username="ccloomi" size={64} /></a></td>
         <td>Xianjun Chen</td>
         <td><a href="https://people.apache.org/committer-index.html#ccloomi">ccloomi</a></td>
         <td><a href="https://github.com/ccloomi">ccloomi</a></td>
@@ -354,7 +355,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/lishuo5263"><img width="64" src="https://github.com/lishuo5263.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/lishuo5263"><GitHubAvatar username="lishuo5263" size={64} /></a></td>
         <td>Shuo Li</td>
         <td><a href="https://people.apache.org/committer-index.html#lishuo">lishuo</a></td>
         <td><a href="https://github.com/lishuo5263">lishuo5263</a></td>
@@ -362,7 +363,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/lahmxu"><img width="64" src="https://github.com/lahmxu.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/lahmxu"><GitHubAvatar username="lahmxu" size={64} /></a></td>
         <td>Jun Xu</td>
         <td><a href="https://people.apache.org/committer-index.html#lahmxu">lahmxu</a></td>
         <td><a href="https://github.com/lahmxu">lahmxu</a></td>
@@ -370,7 +371,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/zhc00"><img width="64" src="https://github.com/zhc00.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/zhc00"><GitHubAvatar username="zhc00" size={64} /></a></td>
         <td>Haochao Zhuang</td>
         <td><a href="https://people.apache.org/committer-index.html#daming">daming</a></td>
         <td><a href="https://github.com/zhc00">zhc00</a></td>
@@ -378,7 +379,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-         <td><a href="https://github.com/mahaitao617"><img width="64" src="https://github.com/mahaitao617.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+         <td><a href="https://github.com/mahaitao617"><GitHubAvatar username="mahaitao617" size={64} /></a></td>
          <td>mahaitao</td>
          <td><a href="https://people.apache.org/committer-index.html#mahaitao">mahaitao</a></td>
          <td><a href="https://github.com/mahaitao617">mahaitao617</a></td>
@@ -386,7 +387,7 @@ tags: ["Team"]
          <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/ShawnJim"><img width="64" src="https://github.com/ShawnJim.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/ShawnJim"><GitHubAvatar username="ShawnJim" size={64} /></a></td>
         <td>Zhenxiao Jin</td>
         <td><a href="https://people.apache.org/committer-index.html#jinzhenxiao">jinzhenxiao</a></td>
         <td><a href="https://github.com/ShawnJim">Shawn Jim</a></td>
@@ -394,7 +395,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/tian-pengfei"><img width="64" src="https://github.com/tian-pengfei.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/tian-pengfei"><GitHubAvatar username="tian-pengfei" size={64} /></a></td>
         <td>Pengfei Tian</td>
         <td><a href="https://people.apache.org/committer-index.html#tianpengfei">tianpengfei</a></td>
         <td><a href="https://github.com/tian-pengfei">tian-pengfei</a></td>
@@ -402,7 +403,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/HaiqiQin"><img width="64" src="https://github.com/HaiqiQin.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/HaiqiQin"><GitHubAvatar username="HaiqiQin" size={64} /></a></td>
         <td>Haiqi Qin</td>
         <td><a href="https://people.apache.org/committer-index.html#haiqi">haiqi</a></td>
         <td><a href="https://github.com/HaiqiQin">HaiqiQin</a></td>
@@ -410,7 +411,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/847850277"><img width="64" src="https://github.com/847850277.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/847850277"><GitHubAvatar username="847850277" size={64} /></a></td>
         <td>Peng Zheng</td>
         <td><a href="https://people.apache.org/committer-index.html#penzheng">penzheng</a></td>
         <td><a href="https://github.com/847850277">847850277</a></td>
@@ -418,7 +419,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/lianjunwei"><img width="64" src="https://github.com/lianjunwei.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/lianjunwei"><GitHubAvatar username="lianjunwei" size={64} /></a></td>
         <td>Junwei Lian</td>
         <td><a href="https://people.apache.org/committer-index.html#lianjunwei">lianjunwei</a></td>
         <td><a href="https://github.com/lianjunwei">lianjunwei</a></td>
@@ -426,7 +427,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/damonxue"><img width="64" src="https://github.com/damonxue.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/damonxue"><GitHubAvatar username="damonxue" size={64} /></a></td>
         <td>Damon Xue</td>
         <td><a href="https://people.apache.org/committer-index.html#xuehuilang">xuehuilang</a></td>
         <td><a href="https://github.com/damonxue">xuehuilang</a></td>
@@ -434,7 +435,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/misaya295"><img width="64" src="https://github.com/misaya295.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/misaya295"><GitHubAvatar username="misaya295" size={64} /></a></td>
         <td>Wenkang Chen</td>
         <td><a href="https://people.apache.org/committer-index.html#chenwenkang">chenwenkang</a></td>
         <td><a href="https://github.com/misaya295">chenwenkang</a></td>
@@ -442,7 +443,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/kerwin612"><img width="64" src="https://github.com/kerwin612.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/kerwin612"><GitHubAvatar username="kerwin612" size={64} /></a></td>
         <td>Le Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#kerwin612">kerwin612</a></td>
         <td><a href="https://github.com/kerwin612">kerwin612</a></td>
@@ -450,7 +451,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/VampireAchao"><img width="64" src="https://github.com/VampireAchao.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/VampireAchao"><GitHubAvatar username="VampireAchao" size={64} /></a></td>
         <td>achao</td>
         <td><a href="https://people.apache.org/committer-index.html#achao">achao</a></td>
         <td><a href="https://github.com/VampireAchao">achao</a></td>
@@ -458,7 +459,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/xcsnx"><img width="64" src="https://github.com/xcsnx.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/xcsnx"><GitHubAvatar username="xcsnx" size={64} /></a></td>
         <td>xcsnx</td>
         <td><a href="https://people.apache.org/committer-index.html#xcsnx">xcsnx</a></td>
         <td><a href="https://github.com/xcsnx">xcsnx</a></td>
@@ -466,7 +467,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/yuluo-yx"><img width="64" src="https://github.com/yuluo-yx.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/yuluo-yx"><GitHubAvatar username="yuluo-yx" size={64} /></a></td>
         <td>yuluo-yx</td>
         <td><a href="https://people.apache.org/committer-index.html#xcsnx">yuluo-yx</a></td>
         <td><a href="https://github.com/yuluo-yx">yuluo-yx</a></td>
@@ -474,7 +475,7 @@ tags: ["Team"]
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/Wweiei"><img width="64" src="https://github.com/Wweiei.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/Wweiei"><GitHubAvatar username="Wweiei" size={64} /></a></td>
         <td>Wei Wei</td>
         <td><a href="https://people.apache.org/committer-index.html#weiwei">weiwei</a></td>
         <td><a href="https://github.com/Wweiei">Wweiei</a></td>
@@ -485,6 +486,7 @@ tags: ["Team"]
 
 ## 贡献者
 
+import GitHubAvatar from "@site/src/components/GitHubAvatar";
 import Contributors from '@site/src/components/Contributors';
 
 目前已经有上百位小伙伴为Apache ShenYu 贡献了文章和代码，非常感谢他们！

--- a/i18n/zh/docusaurus-plugin-content-pages/team.mdx
+++ b/i18n/zh/docusaurus-plugin-content-pages/team.mdx
@@ -486,7 +486,6 @@ import GitHubAvatar from "@site/src/components/GitHubAvatar";
 
 ## 贡献者
 
-import GitHubAvatar from "@site/src/components/GitHubAvatar";
 import Contributors from '@site/src/components/Contributors';
 
 目前已经有上百位小伙伴为Apache ShenYu 贡献了文章和代码，非常感谢他们！

--- a/src/components/GitHubAvatar.tsx
+++ b/src/components/GitHubAvatar.tsx
@@ -1,32 +1,82 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 interface Props {
   username: string;
   size?: number;
 }
 
-export default function GitHubAvatar({ username, size = 64 }: Props) {
-  const [failed, setFailed] = useState(false);
+const PALETTE = [
+  '#1abc9c', '#2ecc71', '#3498db', '#9b59b6', '#34495e',
+  '#16a085', '#27ae60', '#2980b9', '#8e44ad', '#2c3e50',
+  '#f39c12', '#d35400', '#c0392b', '#e67e22', '#7f8c8d',
+];
 
-  if (failed) {
+function getInitials(name: string): string {
+  const letters = name.replace(/[^a-zA-Z]/g, '');
+  return letters.slice(0, 2).toUpperCase() || name.charAt(0).toUpperCase();
+}
+
+function getColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return PALETTE[Math.abs(hash) % PALETTE.length];
+}
+
+export default function GitHubAvatar({ username, size = 64 }: Props) {
+  const [loaded, setLoaded] = useState(false);
+  const imgRef = useRef<HTMLImageElement>(null);
+  const initials = getInitials(username);
+  const bgColor = getColor(username);
+  const fontSize = initials.length === 2 ? size * 0.36 : size * 0.44;
+
+  useEffect(() => {
+    const img = new Image();
+    img.referrerPolicy = 'no-referrer';
+    img.onload = () => setLoaded(true);
+    img.onerror = () => {}; // keep showing initials
+    img.src = `https://github.com/${username}.png`;
+    return () => {
+      img.onload = null;
+      img.onerror = null;
+    };
+  }, [username]);
+
+  if (loaded) {
     return (
       <img
+        ref={imgRef}
         width={size}
         height={size}
-        src="/img/team/default-avatar.svg"
+        src={`https://github.com/${username}.png`}
+        referrerPolicy="no-referrer"
         alt={`${username}'s avatar`}
+        style={{ borderRadius: 4 }}
       />
     );
   }
 
   return (
-    <img
+    <svg
       width={size}
       height={size}
-      src={`https://github.com/${username}.png`}
-      referrerPolicy="no-referrer"
-      alt={`${username}'s avatar`}
-      onError={() => setFailed(true)}
-    />
+      viewBox={`0 0 ${size} ${size}`}
+      aria-label={`${username}'s avatar`}
+    >
+      <rect fill={bgColor} width={size} height={size} rx={4} />
+      <text
+        x={size / 2}
+        y={size / 2}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill="#fff"
+        fontSize={fontSize}
+        fontFamily="system-ui, -apple-system, sans-serif"
+        fontWeight={600}
+      >
+        {initials}
+      </text>
+    </svg>
   );
 }

--- a/src/components/GitHubAvatar.tsx
+++ b/src/components/GitHubAvatar.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+
+interface Props {
+  username: string;
+  size?: number;
+}
+
+export default function GitHubAvatar({ username, size = 64 }: Props) {
+  const [failed, setFailed] = useState(false);
+
+  if (failed) {
+    return (
+      <img
+        width={size}
+        height={size}
+        src="/img/team/default-avatar.svg"
+        alt={`${username}'s avatar`}
+      />
+    );
+  }
+
+  return (
+    <img
+      width={size}
+      height={size}
+      src={`https://github.com/${username}.png`}
+      referrerPolicy="no-referrer"
+      alt={`${username}'s avatar`}
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/src/pages/team.mdx
+++ b/src/pages/team.mdx
@@ -23,207 +23,207 @@ The team always insists on community over code. We are looking forward to more p
         <th><b></b></th>
     </tr>
     <tr>
-        <td><a href="http://github.com/yu199195"><img width="64" src="https://avatars.githubusercontent.com/u/9673503?v=4"/></a></td>
+        <td><a href="https://github.com/yu199195"><img width="64" src="https://github.com/yu199195.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Yu Xiao</td>
         <td><a href="https://people.apache.org/committer-index.html#xiaoyu">xiaoyu</a></td>
-        <td><a href="http://github.com/yu199195">yu199195</a></td>
+        <td><a href="https://github.com/yu199195">yu199195</a></td>
         <td>Founder, V.P. and Chair of PMC</td>
         <td><a href="https://twitter.com/yu199195"><img width="32" src="https://shenyu.apache.org/img/community/twitterblue.png"/>yu199195</a></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/tuohai666"><img width="64" src="https://avatars.githubusercontent.com/u/24643893?v=4"/></a></td>
+        <td><a href="https://github.com/tuohai666"><img width="64" src="https://github.com/tuohai666.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Yonglun Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#zhangyonglun">zhangyonglun</a></td>
-        <td><a href="http://github.com/tuohai666">tuohai666</a></td>
+        <td><a href="https://github.com/tuohai666">tuohai666</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/WillemJiang"><img width="64" src="https://avatars.githubusercontent.com/u/219644?v=4"/></a></td>
+        <td><a href="https://github.com/WillemJiang"><img width="64" src="https://github.com/WillemJiang.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Willem Ning Jiang</td>
         <td><a href="https://people.apache.org/committer-index.html#ningjiang">ningjiang</a></td>
-        <td><a href="http://github.com/WillemJiang">WillemJiang</a></td>
+        <td><a href="https://github.com/WillemJiang">WillemJiang</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/justinmclean"><img width="64" src="https://avatars.githubusercontent.com/u/144504?v=4"/></a></td>
+        <td><a href="https://github.com/justinmclean"><img width="64" src="https://github.com/justinmclean.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Justin Mclean</td>
         <td><a href="https://people.apache.org/committer-index.html#jmclean">jmclean</a></td>
-        <td><a href="http://github.com/justinmclean">justinmclean</a></td>
+        <td><a href="https://github.com/justinmclean">justinmclean</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/Apache9"><img width="64" src="https://avatars.githubusercontent.com/u/4958168?v=4"/></a></td>
+        <td><a href="https://github.com/Apache9"><img width="64" src="https://github.com/Apache9.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Duo Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#zhangduo">zhangduo</a></td>
-        <td><a href="http://github.com/Apache9">Apache9</a></td>
+        <td><a href="https://github.com/Apache9">Apache9</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/atris"><img width="64" src="https://avatars.githubusercontent.com/u/1724131?v=4"/></a></td>
+        <td><a href="https://github.com/atris"><img width="64" src="https://github.com/atris.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Atri Sharma</td>
         <td><a href="https://people.apache.org/committer-index.html#atri">atri</a></td>
-        <td><a href="http://github.com/atris">atris</a></td>
+        <td><a href="https://github.com/atris">atris</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/sunjincheng121"><img width="64" src="https://avatars.githubusercontent.com/u/22488084?v=4"/></a></td>
+        <td><a href="https://github.com/sunjincheng121"><img width="64" src="https://github.com/sunjincheng121.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Jincheng Sun</td>
         <td><a href="https://people.apache.org/committer-index.html#jincheng">jincheng</a></td>
-        <td><a href="http://github.com/sunjincheng121">sunjincheng121</a></td>
+        <td><a href="https://github.com/sunjincheng121">sunjincheng121</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/djkevincr"><img width="64" src="https://avatars.githubusercontent.com/u/1346010?v=4"/></a></td>
+        <td><a href="https://github.com/djkevincr"><img width="64" src="https://github.com/djkevincr.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Kevin Ratnasekera</td>
         <td><a href="https://people.apache.org/committer-index.html#djkevincr">djkevincr</a></td>
-        <td><a href="http://github.com/djkevincr">djkevincr</a></td>
+        <td><a href="https://github.com/djkevincr">djkevincr</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/dengliming"><img width="64" src="https://avatars.githubusercontent.com/u/7796156?v=4"/></a></td>
+        <td><a href="https://github.com/dengliming"><img width="64" src="https://github.com/dengliming.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Liming Deng</td>
         <td><a href="https://people.apache.org/committer-index.html#dengliming">dengliming</a></td>
-        <td><a href="http://github.com/dengliming">dengliming</a></td>
+        <td><a href="https://github.com/dengliming">dengliming</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/nuo-promise"><img width="64" src="https://avatars.githubusercontent.com/u/46160170?v=4"/></a></td>
+        <td><a href="https://github.com/nuo-promise"><img width="64" src="https://github.com/nuo-promise.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>JianMing Ding</td>
         <td><a href="https://people.apache.org/committer-index.html#nuoyan">nuoyan</a></td>
-        <td><a href="http://github.com/nuo-promise">nuo-promise</a></td>
+        <td><a href="https://github.com/nuo-promise">nuo-promise</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/tydhot"><img width="64" src="https://avatars.githubusercontent.com/u/27889201?v=4"/></a></td>
+        <td><a href="https://github.com/tydhot"><img width="64" src="https://github.com/tydhot.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Tang Yudong</td>
         <td><a href="https://people.apache.org/committer-index.html#tydhot">tydhot</a></td>
-        <td><a href="http://github.com/tydhot">tydhot</a></td>
+        <td><a href="https://github.com/tydhot">tydhot</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/SaberSola"><img width="64" src="https://avatars.githubusercontent.com/u/24998393?v=4"/></a></td>
+        <td><a href="https://github.com/SaberSola"><img width="64" src="https://github.com/SaberSola.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Lei Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#sabersola">sabersola</a></td>
-        <td><a href="http://github.com/SaberSola">SaberSola</a></td>
+        <td><a href="https://github.com/SaberSola">SaberSola</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/qicz"><img width="64" src="https://avatars.githubusercontent.com/u/2174082?v=4"/></a></td>
+        <td><a href="https://github.com/qicz"><img width="64" src="https://github.com/qicz.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Congqi Zhu</td>
         <td><a href="https://people.apache.org/committer-index.html#qicz">qicz</a></td>
-        <td><a href="http://github.com/qicz">qicz</a></td>
+        <td><a href="https://github.com/qicz">qicz</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/HessTina-YuI"><img width="64" src="https://avatars.githubusercontent.com/u/13451528?v=4"/></a></td>
+        <td><a href="https://github.com/HessTina-YuI"><img width="64" src="https://github.com/HessTina-YuI.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Yi Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#yui">yui</a></td>
-        <td><a href="http://github.com/HessTina-YuI">HessTina-YuI</a></td>
+        <td><a href="https://github.com/HessTina-YuI">HessTina-YuI</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/loongs-zhang"><img width="64" src="https://avatars.githubusercontent.com/u/38336731?v=4"/></a></td>
+        <td><a href="https://github.com/loongs-zhang"><img width="64" src="https://github.com/loongs-zhang.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>ZiCheng Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#zhangzicheng">zhangzicheng</a></td>
-        <td><a href="http://github.com/loongs-zhang">dragon-zhang</a></td>
+        <td><a href="https://github.com/loongs-zhang">dragon-zhang</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/JooKS-me"><img width="64" src="https://avatars.githubusercontent.com/u/62384022?v=4"/></a></td>
+        <td><a href="https://github.com/JooKS-me"><img width="64" src="https://github.com/JooKS-me.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Kunshuai Zhu</td>
         <td><a href="https://people.apache.org/committer-index.html#jooks">jooks</a></td>
-        <td><a href="http://github.com/JooKS-me">JooKS-me</a></td>
+        <td><a href="https://github.com/JooKS-me">JooKS-me</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/midnight2104"><img width="64" src="https://avatars.githubusercontent.com/u/13334620?v=4"/></a></td>
+        <td><a href="https://github.com/midnight2104"><img width="64" src="https://github.com/midnight2104.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Liang Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#midnight2104">midnight2104</a></td>
-        <td><a href="http://github.com/midnight2104">midnight2104</a></td>
+        <td><a href="https://github.com/midnight2104">midnight2104</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/li-keguo"><img width="64" src="https://avatars.githubusercontent.com/u/33576070?v=4"/></a></td>
+        <td><a href="https://github.com/li-keguo"><img width="64" src="https://github.com/li-keguo.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Keguo Li</td>
         <td><a href="https://people.apache.org/committer-index.html#likeguo">likeguo</a></td>
-        <td><a href="http://github.com/li-keguo">li-keguo</a></td>
+        <td><a href="https://github.com/li-keguo">li-keguo</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/impactCn"><img width="64" src="https://avatars.githubusercontent.com/u/35489877?v=4"/></a></td>
+        <td><a href="https://github.com/impactCn"><img width="64" src="https://github.com/impactCn.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>SiYing Zheng</td>
         <td><a href="https://people.apache.org/committer-index.html#impactcn">impactcn</a></td>
-        <td><a href="http://github.com/impactCn">impactCn</a></td>
+        <td><a href="https://github.com/impactCn">impactCn</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/KevinClair"><img width="64" src="https://avatars.githubusercontent.com/u/37257651?v=4"/></a></td>
+        <td><a href="https://github.com/KevinClair"><img width="64" src="https://github.com/KevinClair.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>MingJie Song</td>
         <td><a href="https://people.apache.org/committer-index.html#kevinclair">kevinclair</a></td>
-        <td><a href="http://github.com/KevinClair">KevinClair</a></td>
+        <td><a href="https://github.com/KevinClair">KevinClair</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/fengzhenbing"><img width="64" src="https://avatars.githubusercontent.com/u/4169359?v=4"/></a></td>
+        <td><a href="https://github.com/fengzhenbing"><img width="64" src="https://github.com/fengzhenbing.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Zhenbing Feng</td>
         <td><a href="https://people.apache.org/committer-index.html#fengzhenbing">fengzhenbing</a></td>
-        <td><a href="http://github.com/fengzhenbing">fengzhenbing</a></td>
+        <td><a href="https://github.com/fengzhenbing">fengzhenbing</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/asxing"><img width="64" src="https://avatars.githubusercontent.com/u/22816271?v=4"/></a></td>
+        <td><a href="https://github.com/asxing"><img width="64" src="https://github.com/asxing.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Asxing</td>
         <td><a href="https://people.apache.org/committer-index.html#asxing">asxing</a></td>
-        <td><a href="http://github.com/asxing">asxing</a></td>
+        <td><a href="https://github.com/asxing">asxing</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/lw1243925457"><img width="64" src="https://avatars.githubusercontent.com/u/11513436?v=4"/></a></td>
+        <td><a href="https://github.com/lw1243925457"><img width="64" src="https://github.com/lw1243925457.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Wei Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#lw1243925457">lw1243925457</a></td>
-        <td><a href="http://github.com/lw1243925457">lw1243925457</a></td>
+        <td><a href="https://github.com/lw1243925457">lw1243925457</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/moremind"><img width="64" src="https://avatars.githubusercontent.com/u/20184263?v=4"/></a></td>
+        <td><a href="https://github.com/moremind"><img width="64" src="https://github.com/moremind.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Fengen He</td>
         <td><a href="https://people.apache.org/committer-index.html#hefengen">hefengen</a></td>
-        <td><a href="http://github.com/moremind">moremind</a></td>
+        <td><a href="https://github.com/moremind">moremind</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/yunlongn"><img width="64" src="https://avatars.githubusercontent.com/u/38271111?v=4"/></a></td>
+        <td><a href="https://github.com/yunlongn"><img width="64" src="https://github.com/yunlongn.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Yunlong Lee</td>
         <td><a href="https://people.apache.org/committer-index.html#yunlong">yunlong</a></td>
-        <td><a href="http://github.com/yunlongn">yunlongn</a></td>
+        <td><a href="https://github.com/yunlongn">yunlongn</a></td>
         <td>PMC</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/aias00"><img width="64" src="https://avatars.githubusercontent.com/u/25810623?v=4"/></a></td>
+        <td><a href="https://github.com/aias00"><img width="64" src="https://github.com/aias00.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Hongyu Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#liuhongyu">liuhongyu</a></td>
         <td><a href="https://github.com/aias00">liuhongyu</a></td>
@@ -231,215 +231,215 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/prFor"><img width="64" src="https://avatars.githubusercontent.com/u/4089611?v=4"/></a></td>
+        <td><a href="https://github.com/prFor"><img width="64" src="https://github.com/prFor.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Bin Chen</td>
         <td><a href="https://people.apache.org/committer-index.html#sixh">sixh</a></td>
-        <td><a href="http://github.com/prFor">prFor</a></td>
+        <td><a href="https://github.com/prFor">prFor</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/haibo-duan"><img width="64" src="https://avatars.githubusercontent.com/u/7974845?v=4"/></a></td>
+        <td><a href="https://github.com/haibo-duan"><img width="64" src="https://github.com/haibo-duan.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Haibo Duan</td>
         <td><a href="https://people.apache.org/committer-index.html#haiboduan">haiboduan</a></td>
-        <td><a href="http://github.com/haibo-duan">haibo-duan</a></td>
+        <td><a href="https://github.com/haibo-duan">haibo-duan</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/renzhuyan"><img width="64" src="https://avatars.githubusercontent.com/u/21033025?v=4"/></a></td>
+        <td><a href="https://github.com/renzhuyan"><img width="64" src="https://github.com/renzhuyan.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>RenZhu Yan</td>
         <td><a href="https://people.apache.org/committer-index.html#renzhuyan">renzhuyan</a></td>
-        <td><a href="http://github.com/renzhuyan">renzhuyan</a></td>
+        <td><a href="https://github.com/renzhuyan">renzhuyan</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/hgaol"><img width="64" src="https://avatars.githubusercontent.com/u/11908658?v=4"/></a></td>
+        <td><a href="https://github.com/hgaol"><img width="64" src="https://github.com/hgaol.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Han Gao</td>
         <td><a href="https://people.apache.org/committer-index.html#gaohan">gaohan</a></td>
-        <td><a href="http://github.com/hgaol">hgaol</a></td>
+        <td><a href="https://github.com/hgaol">hgaol</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/hutaishi"><img width="64" src="https://avatars.githubusercontent.com/u/12478263?v=4"/></a></td>
+        <td><a href="https://github.com/hutaishi"><img width="64" src="https://github.com/hutaishi.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>TaiShi Hu</td>
         <td><a href="https://people.apache.org/committer-index.html#hutaishi">hutaishi</a></td>
-        <td><a href="http://github.com/hutaishi">hutaishi</a></td>
+        <td><a href="https://github.com/hutaishi">hutaishi</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/daiwenyu"><img width="64" src="https://avatars.githubusercontent.com/u/16659386?v=4"/></a></td>
+        <td><a href="https://github.com/daiwenyu"><img width="64" src="https://github.com/daiwenyu.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>WenYu Dai</td>
         <td><a href="https://people.apache.org/committer-index.html#dayu">dayu</a></td>
-        <td><a href="http://github.com/daiwenyu">daiwenyu</a></td>
+        <td><a href="https://github.com/daiwenyu">daiwenyu</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/lxl910128"><img width="64" src="https://avatars.githubusercontent.com/u/8736745?v=4"/></a></td>
+        <td><a href="https://github.com/lxl910128"><img width="64" src="https://github.com/lxl910128.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>XiaoLong Luo</td>
         <td><a href="https://people.apache.org/committer-index.html#luoxiaolong">luoxiaolong</a></td>
-        <td><a href="http://github.com/lxl910128">lxl910128</a></td>
+        <td><a href="https://github.com/lxl910128">lxl910128</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/ttttangzhen"><img width="64" src="https://avatars.githubusercontent.com/u/74766688?v=4"/></a></td>
+        <td><a href="https://github.com/ttttangzhen"><img width="64" src="https://github.com/ttttangzhen.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Zhen Tang</td>
         <td><a href="https://people.apache.org/committer-index.html#alextang">alextang</a></td>
-        <td><a href="http://github.com/ttttangzhen">ttttangzhen</a></td>
+        <td><a href="https://github.com/ttttangzhen">ttttangzhen</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/fightingting"><img width="64" src="https://avatars.githubusercontent.com/u/31699402?v=4"/></a></td>
+        <td><a href="https://github.com/fightingting"><img width="64" src="https://github.com/fightingting.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>TingTing Wang</td>
         <td><a href="https://people.apache.org/committer-index.html#fightingting">fightingting</a></td>
-        <td><a href="http://github.com/fightingting">fightingting</a></td>
+        <td><a href="https://github.com/fightingting">fightingting</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/kimmking"><img width="64" src="https://avatars.githubusercontent.com/u/807508?v=4"/></a></td>
+        <td><a href="https://github.com/kimmking"><img width="64" src="https://github.com/kimmking.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Kimm King</td>
         <td><a href="https://people.apache.org/committer-index.html#kimmking">kimmking</a></td>
-        <td><a href="http://github.com/kimmking">kimmking</a></td>
+        <td><a href="https://github.com/kimmking">kimmking</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/0x12FD16B"><img width="64" src="https://avatars.githubusercontent.com/u/8335369?v=4"/></a></td>
+        <td><a href="https://github.com/0x12FD16B"><img width="64" src="https://github.com/0x12FD16B.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>David Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#hex12fd16b">hex12fd16b</a></td>
-        <td><a href="http://github.com/0x12FD16B">0x12FD16B</a></td>
+        <td><a href="https://github.com/0x12FD16B">0x12FD16B</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/huangxfchn"><img width="64" src="https://avatars.githubusercontent.com/u/17267069?v=4"/></a></td>
+        <td><a href="https://github.com/huangxfchn"><img width="64" src="https://github.com/huangxfchn.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>XiaoFeng Huang</td>
         <td><a href="https://people.apache.org/committer-index.html#huangxfchn">huangxfchn</a></td>
-        <td><a href="http://github.com/huangxfchn">huangxfchn</a></td>
+        <td><a href="https://github.com/huangxfchn">huangxfchn</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/xlgm"><img width="64" src="https://avatars.githubusercontent.com/u/11422929?v=4"/></a></td>
+        <td><a href="https://github.com/xlgm"><img width="64" src="https://github.com/xlgm.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Meng Gao</td>
         <td><a href="https://people.apache.org/committer-index.html#zjntgao">zjntgao</a></td>
-        <td><a href="http://github.com/xlgm">xlgm</a></td>
+        <td><a href="https://github.com/xlgm">xlgm</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/SteNicholas"><img width="64" src="https://avatars.githubusercontent.com/u/10048174?v=4"/></a></td>
+        <td><a href="https://github.com/SteNicholas"><img width="64" src="https://github.com/SteNicholas.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Nicholas Jiang</td>
         <td><a href="https://people.apache.org/committer-index.html#nicholasjiang">nicholasjiang</a></td>
-        <td><a href="http://github.com/SteNicholas">SteNicholas</a></td>
+        <td><a href="https://github.com/SteNicholas">SteNicholas</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/ccloomi"><img width="64" src="https://avatars.githubusercontent.com/u/8596174?v=4"/></a></td>
+        <td><a href="https://github.com/ccloomi"><img width="64" src="https://github.com/ccloomi.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Xianjun Chen</td>
         <td><a href="https://people.apache.org/committer-index.html#ccloomi">ccloomi</a></td>
-        <td><a href="http://github.com/ccloomi">ccloomi</a></td>
+        <td><a href="https://github.com/ccloomi">ccloomi</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/lishuo5263"><img width="64" src="https://avatars.githubusercontent.com/u/19170961?v=4"/></a></td>
+        <td><a href="https://github.com/lishuo5263"><img width="64" src="https://github.com/lishuo5263.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Shuo Li</td>
         <td><a href="https://people.apache.org/committer-index.html#lishuo">lishuo</a></td>
-        <td><a href="http://github.com/lishuo5263">lishuo5263</a></td>
+        <td><a href="https://github.com/lishuo5263">lishuo5263</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/lahmxu"><img width="64" src="https://avatars.githubusercontent.com/u/31627887?v=4"/></a></td>
+        <td><a href="https://github.com/lahmxu"><img width="64" src="https://github.com/lahmxu.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Jun Xu</td>
         <td><a href="https://people.apache.org/committer-index.html#lahmxu">lahmxu</a></td>
-        <td><a href="http://github.com/lahmxu">lahmxu</a></td>
+        <td><a href="https://github.com/lahmxu">lahmxu</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/zhc00"><img width="64" src="https://avatars.githubusercontent.com/u/104989765?v=4"/></a></td>
+        <td><a href="https://github.com/zhc00"><img width="64" src="https://github.com/zhc00.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Haochao Zhuang</td>
         <td><a href="https://people.apache.org/committer-index.html#lahmxu">daming</a></td>
-        <td><a href="http://github.com/zhc00">zhc00</a></td>
+        <td><a href="https://github.com/zhc00">zhc00</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="http://github.com/mahaitao617"><img width="64" src="https://avatars.githubusercontent.com/u/12776225?v=4"/></a></td>
+        <td><a href="https://github.com/mahaitao617"><img width="64" src="https://github.com/mahaitao617.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>mahaitao</td>
         <td><a href="https://people.apache.org/committer-index.html#mahaitao">mahaitao</a></td>
-        <td><a href="http://github.com/mahaitao617">mahaitao617</a></td>
+        <td><a href="https://github.com/mahaitao617">mahaitao617</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/ShawnJim"><img width="64" src="https://avatars.githubusercontent.com/u/32192263?v=4"/></a></td>
+        <td><a href="https://github.com/ShawnJim"><img width="64" src="https://github.com/ShawnJim.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Zhenxiao Jin</td>
         <td><a href="https://people.apache.org/committer-index.html#jinzhenxiao">jinzhenxiao</a></td>
-        <td><a href="http://github.com/ShawnJim">Shawn Jim</a></td>
+        <td><a href="https://github.com/ShawnJim">Shawn Jim</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/tian-pengfei"><img width="64" src="https://avatars.githubusercontent.com/u/42602026?s=96&v=4"/></a></td>
+        <td><a href="https://github.com/tian-pengfei"><img width="64" src="https://github.com/tian-pengfei.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Pengfei Tian</td>
         <td><a href="https://people.apache.org/committer-index.html#tianpengfei">tianpengfei</a></td>
-        <td><a href="http://github.com/tian-pengfei">tian-pengfei</a></td>
+        <td><a href="https://github.com/tian-pengfei">tian-pengfei</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/HaiqiQin"><img width="64" src="https://avatars.githubusercontent.com/u/80969210?v=4"/></a></td>
+        <td><a href="https://github.com/HaiqiQin"><img width="64" src="https://github.com/HaiqiQin.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Haiqi Qin</td>
         <td><a href="https://people.apache.org/committer-index.html#haiqi">haiqi</a></td>
-        <td><a href="http://github.com/HaiqiQin">HaiqiQin</a></td>
+        <td><a href="https://github.com/HaiqiQin">HaiqiQin</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/847850277"><img width="64" src="https://avatars.githubusercontent.com/u/12622645?v=4"/></a></td>
+        <td><a href="https://github.com/847850277"><img width="64" src="https://github.com/847850277.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Peng Zheng</td>
         <td><a href="https://people.apache.org/committer-index.html#penzheng">penzheng</a></td>
-        <td><a href="http://github.com/847850277">847850277</a></td>
+        <td><a href="https://github.com/847850277">847850277</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/lianjunwei"><img width="64" src="https://avatars.githubusercontent.com/u/13819823?v=4"/></a></td>
+        <td><a href="https://github.com/lianjunwei"><img width="64" src="https://github.com/lianjunwei.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Junwei Lian</td>
         <td><a href="https://people.apache.org/committer-index.html#lianjunwei">lianjunwei</a></td>
-        <td><a href="http://github.com/lianjunwei">lianjunwei</a></td>
+        <td><a href="https://github.com/lianjunwei">lianjunwei</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/damonxue"><img width="64" src="https://avatars.githubusercontent.com/u/49482363?v=4"/></a></td>
+        <td><a href="https://github.com/damonxue"><img width="64" src="https://github.com/damonxue.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Damon Xue</td>
         <td><a href="https://people.apache.org/committer-index.html#xuehuilang">xuehuilang</a></td>
-        <td><a href="http://github.com/damonxue">xuehuilang</a></td>
+        <td><a href="https://github.com/damonxue">xuehuilang</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/misaya295"><img width="64" src="https://avatars.githubusercontent.com/u/45778734?v=4"/></a></td>
+        <td><a href="https://github.com/misaya295"><img width="64" src="https://github.com/misaya295.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Wenkang Chen</td>
         <td><a href="https://people.apache.org/committer-index.html#chenwenkang">chenwenkang</a></td>
-        <td><a href="http://github.com/misaya295">chenwenkang</a></td>
+        <td><a href="https://github.com/misaya295">chenwenkang</a></td>
         <td>Committer</td>
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/kerwin612"><img width="64" src="https://avatars.githubusercontent.com/u/3371163?v=4"/></a></td>
+        <td><a href="https://github.com/kerwin612"><img width="64" src="https://github.com/kerwin612.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Le Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#kerwin612">kerwin612</a></td>
         <td><a href="https://github.com/kerwin612">kerwin612</a></td>
@@ -447,7 +447,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/VampireAchao"><img width="64" src="https://avatars.githubusercontent.com/u/52746628?v=4"/></a></td>
+        <td><a href="https://github.com/VampireAchao"><img width="64" src="https://github.com/VampireAchao.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>achao</td>
         <td><a href="https://people.apache.org/committer-index.html#achao">achao</a></td>
         <td><a href="https://github.com/VampireAchao">achao</a></td>
@@ -455,7 +455,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/xcsnx"><img width="64" src="https://avatars.githubusercontent.com/u/47652067?v=4"/></a></td>
+        <td><a href="https://github.com/xcsnx"><img width="64" src="https://github.com/xcsnx.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>xcsnx</td>
         <td><a href="https://people.apache.org/committer-index.html#xcsnx">xcsnx</a></td>
         <td><a href="https://github.com/xcsnx">xcsnx</a></td>
@@ -463,7 +463,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/Wweiei"><img width="64" src="https://avatars.githubusercontent.com/u/45253632?v=4"/></a></td>
+        <td><a href="https://github.com/Wweiei"><img width="64" src="https://github.com/Wweiei.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
         <td>Wei Wei</td>
         <td><a href="https://people.apache.org/committer-index.html#weiwei">weiwei</a></td>
         <td><a href="https://github.com/Wweiei">Wweiei</a></td>

--- a/src/pages/team.mdx
+++ b/src/pages/team.mdx
@@ -475,7 +475,6 @@ The team always insists on community over code. We are looking forward to more p
 
 ## Contributors
 
-import GitHubAvatar from "@site/src/components/GitHubAvatar";
 import Contributors from '@site/src/components/Contributors';
 
 Hundreds of people have contributed articles and code to Apache ShenYu so far, thank you very much!

--- a/src/pages/team.mdx
+++ b/src/pages/team.mdx
@@ -4,6 +4,7 @@ keywords: ["Team"]
 description: team
 ---
 
+import GitHubAvatar from "@site/src/components/GitHubAvatar";
 
 ## Apache ShenYu Team
 
@@ -23,7 +24,7 @@ The team always insists on community over code. We are looking forward to more p
         <th><b></b></th>
     </tr>
     <tr>
-        <td><a href="https://github.com/yu199195"><img width="64" src="https://github.com/yu199195.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/yu199195"><GitHubAvatar username="yu199195" size={64} /></a></td>
         <td>Yu Xiao</td>
         <td><a href="https://people.apache.org/committer-index.html#xiaoyu">xiaoyu</a></td>
         <td><a href="https://github.com/yu199195">yu199195</a></td>
@@ -31,7 +32,7 @@ The team always insists on community over code. We are looking forward to more p
         <td><a href="https://twitter.com/yu199195"><img width="32" src="https://shenyu.apache.org/img/community/twitterblue.png"/>yu199195</a></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/tuohai666"><img width="64" src="https://github.com/tuohai666.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/tuohai666"><GitHubAvatar username="tuohai666" size={64} /></a></td>
         <td>Yonglun Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#zhangyonglun">zhangyonglun</a></td>
         <td><a href="https://github.com/tuohai666">tuohai666</a></td>
@@ -39,7 +40,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/WillemJiang"><img width="64" src="https://github.com/WillemJiang.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/WillemJiang"><GitHubAvatar username="WillemJiang" size={64} /></a></td>
         <td>Willem Ning Jiang</td>
         <td><a href="https://people.apache.org/committer-index.html#ningjiang">ningjiang</a></td>
         <td><a href="https://github.com/WillemJiang">WillemJiang</a></td>
@@ -47,7 +48,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/justinmclean"><img width="64" src="https://github.com/justinmclean.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/justinmclean"><GitHubAvatar username="justinmclean" size={64} /></a></td>
         <td>Justin Mclean</td>
         <td><a href="https://people.apache.org/committer-index.html#jmclean">jmclean</a></td>
         <td><a href="https://github.com/justinmclean">justinmclean</a></td>
@@ -55,7 +56,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/Apache9"><img width="64" src="https://github.com/Apache9.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/Apache9"><GitHubAvatar username="Apache9" size={64} /></a></td>
         <td>Duo Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#zhangduo">zhangduo</a></td>
         <td><a href="https://github.com/Apache9">Apache9</a></td>
@@ -63,7 +64,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/atris"><img width="64" src="https://github.com/atris.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/atris"><GitHubAvatar username="atris" size={64} /></a></td>
         <td>Atri Sharma</td>
         <td><a href="https://people.apache.org/committer-index.html#atri">atri</a></td>
         <td><a href="https://github.com/atris">atris</a></td>
@@ -71,7 +72,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/sunjincheng121"><img width="64" src="https://github.com/sunjincheng121.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/sunjincheng121"><GitHubAvatar username="sunjincheng121" size={64} /></a></td>
         <td>Jincheng Sun</td>
         <td><a href="https://people.apache.org/committer-index.html#jincheng">jincheng</a></td>
         <td><a href="https://github.com/sunjincheng121">sunjincheng121</a></td>
@@ -79,7 +80,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/djkevincr"><img width="64" src="https://github.com/djkevincr.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/djkevincr"><GitHubAvatar username="djkevincr" size={64} /></a></td>
         <td>Kevin Ratnasekera</td>
         <td><a href="https://people.apache.org/committer-index.html#djkevincr">djkevincr</a></td>
         <td><a href="https://github.com/djkevincr">djkevincr</a></td>
@@ -87,7 +88,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/dengliming"><img width="64" src="https://github.com/dengliming.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/dengliming"><GitHubAvatar username="dengliming" size={64} /></a></td>
         <td>Liming Deng</td>
         <td><a href="https://people.apache.org/committer-index.html#dengliming">dengliming</a></td>
         <td><a href="https://github.com/dengliming">dengliming</a></td>
@@ -95,7 +96,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/nuo-promise"><img width="64" src="https://github.com/nuo-promise.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/nuo-promise"><GitHubAvatar username="nuo-promise" size={64} /></a></td>
         <td>JianMing Ding</td>
         <td><a href="https://people.apache.org/committer-index.html#nuoyan">nuoyan</a></td>
         <td><a href="https://github.com/nuo-promise">nuo-promise</a></td>
@@ -103,7 +104,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/tydhot"><img width="64" src="https://github.com/tydhot.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/tydhot"><GitHubAvatar username="tydhot" size={64} /></a></td>
         <td>Tang Yudong</td>
         <td><a href="https://people.apache.org/committer-index.html#tydhot">tydhot</a></td>
         <td><a href="https://github.com/tydhot">tydhot</a></td>
@@ -111,7 +112,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/SaberSola"><img width="64" src="https://github.com/SaberSola.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/SaberSola"><GitHubAvatar username="SaberSola" size={64} /></a></td>
         <td>Lei Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#sabersola">sabersola</a></td>
         <td><a href="https://github.com/SaberSola">SaberSola</a></td>
@@ -119,7 +120,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/qicz"><img width="64" src="https://github.com/qicz.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/qicz"><GitHubAvatar username="qicz" size={64} /></a></td>
         <td>Congqi Zhu</td>
         <td><a href="https://people.apache.org/committer-index.html#qicz">qicz</a></td>
         <td><a href="https://github.com/qicz">qicz</a></td>
@@ -127,7 +128,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/HessTina-YuI"><img width="64" src="https://github.com/HessTina-YuI.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/HessTina-YuI"><GitHubAvatar username="HessTina-YuI" size={64} /></a></td>
         <td>Yi Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#yui">yui</a></td>
         <td><a href="https://github.com/HessTina-YuI">HessTina-YuI</a></td>
@@ -135,7 +136,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/loongs-zhang"><img width="64" src="https://github.com/loongs-zhang.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/loongs-zhang"><GitHubAvatar username="loongs-zhang" size={64} /></a></td>
         <td>ZiCheng Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#zhangzicheng">zhangzicheng</a></td>
         <td><a href="https://github.com/loongs-zhang">dragon-zhang</a></td>
@@ -143,7 +144,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/JooKS-me"><img width="64" src="https://github.com/JooKS-me.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/JooKS-me"><GitHubAvatar username="JooKS-me" size={64} /></a></td>
         <td>Kunshuai Zhu</td>
         <td><a href="https://people.apache.org/committer-index.html#jooks">jooks</a></td>
         <td><a href="https://github.com/JooKS-me">JooKS-me</a></td>
@@ -151,7 +152,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/midnight2104"><img width="64" src="https://github.com/midnight2104.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/midnight2104"><GitHubAvatar username="midnight2104" size={64} /></a></td>
         <td>Liang Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#midnight2104">midnight2104</a></td>
         <td><a href="https://github.com/midnight2104">midnight2104</a></td>
@@ -159,7 +160,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/li-keguo"><img width="64" src="https://github.com/li-keguo.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/li-keguo"><GitHubAvatar username="li-keguo" size={64} /></a></td>
         <td>Keguo Li</td>
         <td><a href="https://people.apache.org/committer-index.html#likeguo">likeguo</a></td>
         <td><a href="https://github.com/li-keguo">li-keguo</a></td>
@@ -167,7 +168,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/impactCn"><img width="64" src="https://github.com/impactCn.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/impactCn"><GitHubAvatar username="impactCn" size={64} /></a></td>
         <td>SiYing Zheng</td>
         <td><a href="https://people.apache.org/committer-index.html#impactcn">impactcn</a></td>
         <td><a href="https://github.com/impactCn">impactCn</a></td>
@@ -175,7 +176,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/KevinClair"><img width="64" src="https://github.com/KevinClair.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/KevinClair"><GitHubAvatar username="KevinClair" size={64} /></a></td>
         <td>MingJie Song</td>
         <td><a href="https://people.apache.org/committer-index.html#kevinclair">kevinclair</a></td>
         <td><a href="https://github.com/KevinClair">KevinClair</a></td>
@@ -183,7 +184,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/fengzhenbing"><img width="64" src="https://github.com/fengzhenbing.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/fengzhenbing"><GitHubAvatar username="fengzhenbing" size={64} /></a></td>
         <td>Zhenbing Feng</td>
         <td><a href="https://people.apache.org/committer-index.html#fengzhenbing">fengzhenbing</a></td>
         <td><a href="https://github.com/fengzhenbing">fengzhenbing</a></td>
@@ -191,7 +192,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/asxing"><img width="64" src="https://github.com/asxing.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/asxing"><GitHubAvatar username="asxing" size={64} /></a></td>
         <td>Asxing</td>
         <td><a href="https://people.apache.org/committer-index.html#asxing">asxing</a></td>
         <td><a href="https://github.com/asxing">asxing</a></td>
@@ -199,7 +200,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/lw1243925457"><img width="64" src="https://github.com/lw1243925457.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/lw1243925457"><GitHubAvatar username="lw1243925457" size={64} /></a></td>
         <td>Wei Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#lw1243925457">lw1243925457</a></td>
         <td><a href="https://github.com/lw1243925457">lw1243925457</a></td>
@@ -207,7 +208,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/moremind"><img width="64" src="https://github.com/moremind.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/moremind"><GitHubAvatar username="moremind" size={64} /></a></td>
         <td>Fengen He</td>
         <td><a href="https://people.apache.org/committer-index.html#hefengen">hefengen</a></td>
         <td><a href="https://github.com/moremind">moremind</a></td>
@@ -215,7 +216,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/yunlongn"><img width="64" src="https://github.com/yunlongn.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/yunlongn"><GitHubAvatar username="yunlongn" size={64} /></a></td>
         <td>Yunlong Lee</td>
         <td><a href="https://people.apache.org/committer-index.html#yunlong">yunlong</a></td>
         <td><a href="https://github.com/yunlongn">yunlongn</a></td>
@@ -223,7 +224,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/aias00"><img width="64" src="https://github.com/aias00.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/aias00"><GitHubAvatar username="aias00" size={64} /></a></td>
         <td>Hongyu Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#liuhongyu">liuhongyu</a></td>
         <td><a href="https://github.com/aias00">liuhongyu</a></td>
@@ -231,7 +232,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/prFor"><img width="64" src="https://github.com/prFor.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/prFor"><GitHubAvatar username="prFor" size={64} /></a></td>
         <td>Bin Chen</td>
         <td><a href="https://people.apache.org/committer-index.html#sixh">sixh</a></td>
         <td><a href="https://github.com/prFor">prFor</a></td>
@@ -239,7 +240,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/haibo-duan"><img width="64" src="https://github.com/haibo-duan.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/haibo-duan"><GitHubAvatar username="haibo-duan" size={64} /></a></td>
         <td>Haibo Duan</td>
         <td><a href="https://people.apache.org/committer-index.html#haiboduan">haiboduan</a></td>
         <td><a href="https://github.com/haibo-duan">haibo-duan</a></td>
@@ -247,7 +248,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/renzhuyan"><img width="64" src="https://github.com/renzhuyan.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/renzhuyan"><GitHubAvatar username="renzhuyan" size={64} /></a></td>
         <td>RenZhu Yan</td>
         <td><a href="https://people.apache.org/committer-index.html#renzhuyan">renzhuyan</a></td>
         <td><a href="https://github.com/renzhuyan">renzhuyan</a></td>
@@ -255,7 +256,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/hgaol"><img width="64" src="https://github.com/hgaol.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/hgaol"><GitHubAvatar username="hgaol" size={64} /></a></td>
         <td>Han Gao</td>
         <td><a href="https://people.apache.org/committer-index.html#gaohan">gaohan</a></td>
         <td><a href="https://github.com/hgaol">hgaol</a></td>
@@ -263,7 +264,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/hutaishi"><img width="64" src="https://github.com/hutaishi.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/hutaishi"><GitHubAvatar username="hutaishi" size={64} /></a></td>
         <td>TaiShi Hu</td>
         <td><a href="https://people.apache.org/committer-index.html#hutaishi">hutaishi</a></td>
         <td><a href="https://github.com/hutaishi">hutaishi</a></td>
@@ -271,7 +272,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/daiwenyu"><img width="64" src="https://github.com/daiwenyu.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/daiwenyu"><GitHubAvatar username="daiwenyu" size={64} /></a></td>
         <td>WenYu Dai</td>
         <td><a href="https://people.apache.org/committer-index.html#dayu">dayu</a></td>
         <td><a href="https://github.com/daiwenyu">daiwenyu</a></td>
@@ -279,7 +280,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/lxl910128"><img width="64" src="https://github.com/lxl910128.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/lxl910128"><GitHubAvatar username="lxl910128" size={64} /></a></td>
         <td>XiaoLong Luo</td>
         <td><a href="https://people.apache.org/committer-index.html#luoxiaolong">luoxiaolong</a></td>
         <td><a href="https://github.com/lxl910128">lxl910128</a></td>
@@ -287,7 +288,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/ttttangzhen"><img width="64" src="https://github.com/ttttangzhen.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/ttttangzhen"><GitHubAvatar username="ttttangzhen" size={64} /></a></td>
         <td>Zhen Tang</td>
         <td><a href="https://people.apache.org/committer-index.html#alextang">alextang</a></td>
         <td><a href="https://github.com/ttttangzhen">ttttangzhen</a></td>
@@ -295,7 +296,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/fightingting"><img width="64" src="https://github.com/fightingting.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/fightingting"><GitHubAvatar username="fightingting" size={64} /></a></td>
         <td>TingTing Wang</td>
         <td><a href="https://people.apache.org/committer-index.html#fightingting">fightingting</a></td>
         <td><a href="https://github.com/fightingting">fightingting</a></td>
@@ -303,7 +304,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/kimmking"><img width="64" src="https://github.com/kimmking.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/kimmking"><GitHubAvatar username="kimmking" size={64} /></a></td>
         <td>Kimm King</td>
         <td><a href="https://people.apache.org/committer-index.html#kimmking">kimmking</a></td>
         <td><a href="https://github.com/kimmking">kimmking</a></td>
@@ -311,7 +312,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/0x12FD16B"><img width="64" src="https://github.com/0x12FD16B.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/0x12FD16B"><GitHubAvatar username="0x12FD16B" size={64} /></a></td>
         <td>David Liu</td>
         <td><a href="https://people.apache.org/committer-index.html#hex12fd16b">hex12fd16b</a></td>
         <td><a href="https://github.com/0x12FD16B">0x12FD16B</a></td>
@@ -319,7 +320,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/huangxfchn"><img width="64" src="https://github.com/huangxfchn.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/huangxfchn"><GitHubAvatar username="huangxfchn" size={64} /></a></td>
         <td>XiaoFeng Huang</td>
         <td><a href="https://people.apache.org/committer-index.html#huangxfchn">huangxfchn</a></td>
         <td><a href="https://github.com/huangxfchn">huangxfchn</a></td>
@@ -327,7 +328,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/xlgm"><img width="64" src="https://github.com/xlgm.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/xlgm"><GitHubAvatar username="xlgm" size={64} /></a></td>
         <td>Meng Gao</td>
         <td><a href="https://people.apache.org/committer-index.html#zjntgao">zjntgao</a></td>
         <td><a href="https://github.com/xlgm">xlgm</a></td>
@@ -335,7 +336,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/SteNicholas"><img width="64" src="https://github.com/SteNicholas.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/SteNicholas"><GitHubAvatar username="SteNicholas" size={64} /></a></td>
         <td>Nicholas Jiang</td>
         <td><a href="https://people.apache.org/committer-index.html#nicholasjiang">nicholasjiang</a></td>
         <td><a href="https://github.com/SteNicholas">SteNicholas</a></td>
@@ -343,7 +344,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/ccloomi"><img width="64" src="https://github.com/ccloomi.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/ccloomi"><GitHubAvatar username="ccloomi" size={64} /></a></td>
         <td>Xianjun Chen</td>
         <td><a href="https://people.apache.org/committer-index.html#ccloomi">ccloomi</a></td>
         <td><a href="https://github.com/ccloomi">ccloomi</a></td>
@@ -351,7 +352,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/lishuo5263"><img width="64" src="https://github.com/lishuo5263.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/lishuo5263"><GitHubAvatar username="lishuo5263" size={64} /></a></td>
         <td>Shuo Li</td>
         <td><a href="https://people.apache.org/committer-index.html#lishuo">lishuo</a></td>
         <td><a href="https://github.com/lishuo5263">lishuo5263</a></td>
@@ -359,7 +360,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/lahmxu"><img width="64" src="https://github.com/lahmxu.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/lahmxu"><GitHubAvatar username="lahmxu" size={64} /></a></td>
         <td>Jun Xu</td>
         <td><a href="https://people.apache.org/committer-index.html#lahmxu">lahmxu</a></td>
         <td><a href="https://github.com/lahmxu">lahmxu</a></td>
@@ -367,7 +368,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/zhc00"><img width="64" src="https://github.com/zhc00.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/zhc00"><GitHubAvatar username="zhc00" size={64} /></a></td>
         <td>Haochao Zhuang</td>
         <td><a href="https://people.apache.org/committer-index.html#lahmxu">daming</a></td>
         <td><a href="https://github.com/zhc00">zhc00</a></td>
@@ -375,7 +376,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/mahaitao617"><img width="64" src="https://github.com/mahaitao617.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/mahaitao617"><GitHubAvatar username="mahaitao617" size={64} /></a></td>
         <td>mahaitao</td>
         <td><a href="https://people.apache.org/committer-index.html#mahaitao">mahaitao</a></td>
         <td><a href="https://github.com/mahaitao617">mahaitao617</a></td>
@@ -383,7 +384,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/ShawnJim"><img width="64" src="https://github.com/ShawnJim.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/ShawnJim"><GitHubAvatar username="ShawnJim" size={64} /></a></td>
         <td>Zhenxiao Jin</td>
         <td><a href="https://people.apache.org/committer-index.html#jinzhenxiao">jinzhenxiao</a></td>
         <td><a href="https://github.com/ShawnJim">Shawn Jim</a></td>
@@ -391,7 +392,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/tian-pengfei"><img width="64" src="https://github.com/tian-pengfei.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/tian-pengfei"><GitHubAvatar username="tian-pengfei" size={64} /></a></td>
         <td>Pengfei Tian</td>
         <td><a href="https://people.apache.org/committer-index.html#tianpengfei">tianpengfei</a></td>
         <td><a href="https://github.com/tian-pengfei">tian-pengfei</a></td>
@@ -399,7 +400,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/HaiqiQin"><img width="64" src="https://github.com/HaiqiQin.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/HaiqiQin"><GitHubAvatar username="HaiqiQin" size={64} /></a></td>
         <td>Haiqi Qin</td>
         <td><a href="https://people.apache.org/committer-index.html#haiqi">haiqi</a></td>
         <td><a href="https://github.com/HaiqiQin">HaiqiQin</a></td>
@@ -407,7 +408,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/847850277"><img width="64" src="https://github.com/847850277.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/847850277"><GitHubAvatar username="847850277" size={64} /></a></td>
         <td>Peng Zheng</td>
         <td><a href="https://people.apache.org/committer-index.html#penzheng">penzheng</a></td>
         <td><a href="https://github.com/847850277">847850277</a></td>
@@ -415,7 +416,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/lianjunwei"><img width="64" src="https://github.com/lianjunwei.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/lianjunwei"><GitHubAvatar username="lianjunwei" size={64} /></a></td>
         <td>Junwei Lian</td>
         <td><a href="https://people.apache.org/committer-index.html#lianjunwei">lianjunwei</a></td>
         <td><a href="https://github.com/lianjunwei">lianjunwei</a></td>
@@ -423,7 +424,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/damonxue"><img width="64" src="https://github.com/damonxue.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/damonxue"><GitHubAvatar username="damonxue" size={64} /></a></td>
         <td>Damon Xue</td>
         <td><a href="https://people.apache.org/committer-index.html#xuehuilang">xuehuilang</a></td>
         <td><a href="https://github.com/damonxue">xuehuilang</a></td>
@@ -431,7 +432,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/misaya295"><img width="64" src="https://github.com/misaya295.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/misaya295"><GitHubAvatar username="misaya295" size={64} /></a></td>
         <td>Wenkang Chen</td>
         <td><a href="https://people.apache.org/committer-index.html#chenwenkang">chenwenkang</a></td>
         <td><a href="https://github.com/misaya295">chenwenkang</a></td>
@@ -439,7 +440,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/kerwin612"><img width="64" src="https://github.com/kerwin612.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/kerwin612"><GitHubAvatar username="kerwin612" size={64} /></a></td>
         <td>Le Zhang</td>
         <td><a href="https://people.apache.org/committer-index.html#kerwin612">kerwin612</a></td>
         <td><a href="https://github.com/kerwin612">kerwin612</a></td>
@@ -447,7 +448,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/VampireAchao"><img width="64" src="https://github.com/VampireAchao.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/VampireAchao"><GitHubAvatar username="VampireAchao" size={64} /></a></td>
         <td>achao</td>
         <td><a href="https://people.apache.org/committer-index.html#achao">achao</a></td>
         <td><a href="https://github.com/VampireAchao">achao</a></td>
@@ -455,7 +456,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/xcsnx"><img width="64" src="https://github.com/xcsnx.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/xcsnx"><GitHubAvatar username="xcsnx" size={64} /></a></td>
         <td>xcsnx</td>
         <td><a href="https://people.apache.org/committer-index.html#xcsnx">xcsnx</a></td>
         <td><a href="https://github.com/xcsnx">xcsnx</a></td>
@@ -463,7 +464,7 @@ The team always insists on community over code. We are looking forward to more p
         <td></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/Wweiei"><img width="64" src="https://github.com/Wweiei.png" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2264%22 height=%2264%22 viewBox=%220 0 64 64%22%3E%3Crect fill=%22%23ddd%22 width=%2264%22 height=%2264%22/%3E%3Ctext fill=%22%23999%22 x=%2232%22 y=%2232%22 text-anchor=%22middle%22 dy=%22.3em%22 font-size=%2224%22%3E?%3C/text%3E%3C/svg%3E'"/></a></td>
+        <td><a href="https://github.com/Wweiei"><GitHubAvatar username="Wweiei" size={64} /></a></td>
         <td>Wei Wei</td>
         <td><a href="https://people.apache.org/committer-index.html#weiwei">weiwei</a></td>
         <td><a href="https://github.com/Wweiei">Wweiei</a></td>
@@ -474,6 +475,7 @@ The team always insists on community over code. We are looking forward to more p
 
 ## Contributors
 
+import GitHubAvatar from "@site/src/components/GitHubAvatar";
 import Contributors from '@site/src/components/Contributors';
 
 Hundreds of people have contributed articles and code to Apache ShenYu so far, thank you very much!

--- a/static/img/team/default-avatar.svg
+++ b/static/img/team/default-avatar.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect fill="#e2e8f0" width="64" height="64" rx="4"/>
+  <circle cx="32" cy="24" r="10" fill="#94a3b8"/>
+  <ellipse cx="32" cy="54" rx="16" ry="12" fill="#94a3b8"/>
+</svg>


### PR DESCRIPTION
## Summary of Changes

  Branch: fix/team-page-github-avatar-loading

  Problem: Member avatars on the /team page were failing to load because avatars.githubusercontent.com is unreliable in certain regions. The team page (~55+ members) used direct CDN
   URLs with no error handling.

  Changes across 4 files (+304 / -215 lines):

  1. New: src/components/GitHubAvatar.tsx

  A React component that replaces raw <img> tags. Instead of showing a broken image on failure, it renders initials immediately as an inline SVG (colored background + extracted
  initials from username), then loads the real GitHub avatar in the background. On success it swaps to the photo; on failure it keeps the initials. Users never see a broken image.

  2. New: static/img/team/default-avatar.svg

  A fallback silhouette avatar SVG (kept as a static asset, though the component now uses inline SVG initials instead).

  3. Modified: src/pages/team.mdx (English)

  - All 55+ avatar <img> tags replaced with <GitHubAvatar username="..." size={64} />
  - All http:// GitHub links upgraded to https://
  - Added import GitHubAvatar at top of file

  4. Modified: i18n/zh/docusaurus-plugin-content-pages/team.mdx (Chinese)

  - Same changes as the English file — all avatar tags replaced, all links upgraded to HTTPS

close [#1112](https://github.com/apache/shenyu-website/issues/1112)